### PR TITLE
Allow fix-permissions to fail without failing a build

### DIFF
--- a/bin/fix-permissions
+++ b/bin/fix-permissions
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Allow this script to fail without failing a build
+set +e
+
 # Fix permissions on the given directory to allow group read/write of
 # regular files and execute of directories.
 chgrp -R 0 $1;


### PR DESCRIPTION
If some files can't be updated because the current user doesn't own them or some other reason, the entire build should not fail. This will allow secrets to be injected inside the source tree.