### PR TITLE
Change default image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ else
 	OS := centos7
 endif
 
-BASE_IMAGE_NAME = "base"
+BASE_IMAGE_NAME = "s2i-base"
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,7 +13,7 @@ test -z "$BASE_IMAGE_NAME" && {
     BASE_IMAGE_NAME="${BASE_DIR_NAME#s2i-}"
 }
 
-NAMESPACE="openshift/"
+NAMESPACE="centos/"
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT


### PR DESCRIPTION
This image is built as `centos/s2i-base-centos7` (https://hub.docker.com/r/centos/s2i-base-centos7/). So changing default name for the image.

@bparees Please take a look and merge.