### PR TITLE
Avoid errors when the process does not have enough permissions

### DIFF
--- a/bin/fix-permissions
+++ b/bin/fix-permissions
@@ -3,10 +3,18 @@
 # Allow this script to fail without failing a build
 set +e
 
-# Fix permissions on the given directory to allow group read/write of
+# Fix permissions on the given directory or file to allow group read/write of
 # regular files and execute of directories.
-chgrp -R 0 $1;
-find -L $1 -xtype l -exec chgrp 0 {} \;
-chmod -R g+rw $1;
-find -L $1 -xtype l -exec chmod g+rw {} \;
-find $1 -type d -exec chmod g+x {} +
+
+# If argument does not exist, script will still exit with 0,
+# but at least we'll see something went wrong in the log
+if ! [ -e "$1" ] ; then
+  echo "ERROR: File or directory $1 does not exist." >&2
+fi
+
+# Using --quiet to avoid error messages when there are not enough permissions
+chgrp -R --quiet 0 "$1";
+find -L "$1" -xtype l -exec chgrp --quiet 0 {} \;
+chmod -R --quiet g+rw "$1";
+find -L "$1" -xtype l -exec chmod --quiet g+rw {} \;
+find "$1" -type d -exec chmod --quiet g+x {} +

--- a/bin/fix-permissions
+++ b/bin/fix-permissions
@@ -13,8 +13,7 @@ if ! [ -e "$1" ] ; then
 fi
 
 # Using --quiet to avoid error messages when there are not enough permissions
-chgrp -R --quiet 0 "$1";
-find -L "$1" -xtype l -exec chgrp --quiet 0 {} \;
-chmod -R --quiet g+rw "$1";
-find -L "$1" -xtype l -exec chmod --quiet g+rw {} \;
-find "$1" -type d -exec chmod --quiet g+x {} +
+find -L "$1" \! -gid 0 -exec chgrp 0 {} +
+find -L "$1" \! -perm /g+rw -exec chmod g+rw {} +
+find -L "$1" -perm /u+x -a \! -perm /g+x -exec chmod g+x {} +
+find -L "$1" -type d \! -perm /g+x -exec chmod g+x {} +

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,7 +13,11 @@ test -z "$BASE_IMAGE_NAME" && {
     BASE_IMAGE_NAME="${BASE_DIR_NAME#s2i-}"
 }
 
-NAMESPACE="centos/"
+if [ "${OS}" == "rhel7" ]; then
+    NAMESPACE="rhscl/"
+else
+    NAMESPACE="centos/"
+fi
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT


### PR DESCRIPTION
Sometimes there is not enough permissions to change attributes by `fix-permissions`. It was for example reported in sclorg/mariadb-container#32. This change should make these warnings disappeared.