### PR TITLE
Change image namespace according to provided TARGET

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,7 +13,11 @@ test -z "$BASE_IMAGE_NAME" && {
     BASE_IMAGE_NAME="${BASE_DIR_NAME#s2i-}"
 }
 
-NAMESPACE="centos/"
+if [ "${OS}" == "rhel7" ]; then
+    NAMESPACE="rhscl/"
+else
+    NAMESPACE="centos/"
+fi
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT


### PR DESCRIPTION
Now building with TARGET=rhel7 resulted image uses `centos/` namespace (instead of `rhscl/`) 

@pkubatrh @hhorak @bparees Please review and merge.