### PR TITLE
Avoid errors when the process does not have enough permissions to change attributes

### DIFF
--- a/bin/fix-permissions
+++ b/bin/fix-permissions
@@ -3,11 +3,22 @@
 # Allow this script to fail without failing a build
 set +e
 
-# Fix permissions on the given directory to allow group read/write of
+# Fix permissions on the given directory or file to allow group read/write of
 # regular files and execute of directories.
-chgrp -R 0 $1;
-find -L $1 -xtype l -exec chgrp 0 {} \;
-chmod -R g+rw $1;
-find -L $1 -xtype l -exec chmod g+rw {} \;
-find $1 -type d -exec chmod g+x {} +
+
+# If argument does not exist, script will still exit with 0,
+# but at least we'll see something went wrong in the log
+if ! [ -e "$1" ] ; then
+  echo "ERROR: File or directory $1 does not exist." >&2
+  # We still want to end successfully
+  exit 0
+fi
+
+# Using --quiet to avoid error messages when there are not enough permissions
+find -L "$1" \! -gid 0 -exec chgrp 0 {} +
+find -L "$1" \! -perm /g+rw -exec chmod g+rw {} +
+find -L "$1" -perm /u+x -a \! -perm /g+x -exec chmod g+x {} +
+find -L "$1" -type d \! -perm /g+x -exec chmod g+x {} +
+
+# Allways end successfully
 exit 0


### PR DESCRIPTION
I tried to rebase the original #120 by an innovative way, but it ended bad. This PR is the same as #120.