### PR TITLE
fix fault in fix-permissions where group perms were not set correctly

### DIFF
--- a/bin/fix-permissions
+++ b/bin/fix-permissions
@@ -15,7 +15,7 @@ if ! [ -e "$1" ] ; then
 fi
 
 find -L "$1" \! -gid 0 -exec chgrp 0 {} +
-find -L "$1" \! -perm /g+rw -exec chmod g+rw {} +
+find -L "$1" \! -perm -g+rw -exec chmod g+rw {} +
 find -L "$1" -perm /u+x -a \! -perm /g+x -exec chmod g+x {} +
 find -L "$1" -type d \! -perm /g+x -exec chmod g+x {} +
 


### PR DESCRIPTION
Currently this line means: find all files where group read is not set AND group write is not set, and chmod them g+rw.
I think it should be: find all files where group read is not set OR group write is not set, and chmod them g+rw.

Otherwise files which are already g+r do not become g+rw.

This broke the origin extended image ecosystem test.

@hhorak 