### PR TITLE
Update Dockerfiles

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,9 +1,12 @@
 # This image is the base image for all OpenShift v3 language Docker images.
 FROM centos/s2i-core-centos7
 
-ENV SUMMARY="Base image with essential libraries and tools used as a base for builder images like perl, python, ruby, etc."	\
-    DESCRIPTION="Base image delivers all the essential libraries and tools needed for other builder images like perl, python, \
-ruby, etc. This image uses s2i-core image which defines default user and includes some common scripts for derived builder images."
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,19 @@
 # This image is the base image for all OpenShift v3 language Docker images.
 FROM centos/s2i-core-centos7
 
-MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
+ENV SUMMARY="Base image with essential libraries and tools used as a base for builder images like perl, python, ruby, etc."	\
+    DESCRIPTION="Base image delivers all the essential libraries and tools needed for other builder images like perl, python, \
+ruby, etc. This image uses s2i-core image which defines default user and includes some common scripts for derived builder images."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      com.redhat.component="s2i-base-docker" \
+      name="centos/s2i-base-centos7" \
+      version="1" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # This is the list of basic dependencies that all language Docker image can
 # consume.

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -1,9 +1,12 @@
 # This image is the base image for all OpenShift v3 language Docker images.
 FROM rhscl/s2i-core-rhel7
 
-ENV SUMMARY="Base image with essential libraries and tools used as a base for builder images like perl, python, ruby, etc."	\
-    DESCRIPTION="Base image delivers all the essential libraries and tools needed for other builder images like perl, python, \
-ruby, etc. This image uses s2i-core image which defines default user and includes some common scripts for derived builder images."
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -1,12 +1,18 @@
 # This image is the base image for all OpenShift v3 language Docker images.
 FROM rhscl/s2i-core-rhel7
 
-LABEL \
+ENV SUMMARY="Base image with essential libraries and tools used as a base for builder images like perl, python, ruby, etc."	\
+    DESCRIPTION="Base image delivers all the essential libraries and tools needed for other builder images like perl, python, \
+ruby, etc. This image uses s2i-core image which defines default user and includes some common scripts for derived builder images."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
       com.redhat.component="s2i-base-docker" \
       name="rhscl/s2i-base-rhel7" \
       version="1" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # This is the list of basic dependencies that all language Docker image can
 # consume.

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -10,9 +10,7 @@ LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="s2i core" \
-      # Location of the STI scripts inside the image.
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
-      # DEPRECATED: This label will be kept here for backward compatibility.
       io.s2i.scripts-url=image:///usr/libexec/s2i \
       com.redhat.component="s2i-core-docker" \
       name="centos/s2i-core-centos7" \

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,13 +1,24 @@
 # This image is the base image for all s2i configurable Docker images.
 FROM centos:7
 
-MAINTAINER Jakub Hadvig <jhadvig@redhat.com>
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="Base image delivers all the essential tools needed for using source-to-image \
+and to allow using Software Collection packages. This image also defines default user \
+and includes some common scripts for derived images."
 
-LABEL \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
       # Location of the STI scripts inside the image.
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       # DEPRECATED: This label will be kept here for backward compatibility.
-      io.s2i.scripts-url=image:///usr/libexec/s2i
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.component="s2i-core-docker" \
+      name="centos/s2i-core-centos7" \
+      version="1" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -2,9 +2,9 @@
 FROM centos:7
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
-    DESCRIPTION="Base image delivers all the essential tools needed for using source-to-image \
-and to allow using Software Collection packages. This image also defines default user \
-and includes some common scripts for derived images."
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -1,14 +1,21 @@
 # This image is the base image for all s2i configurable Docker images.
 FROM rhel7
 
-LABEL \
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="Base image delivers all the essential tools needed for using source-to-image \
+and to allow using Software Collection packages. This image also defines default user \
+and includes some common scripts for derived images."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       io.s2i.scripts-url=image:///usr/libexec/s2i \
       com.redhat.component="s2i-core-docker" \
       name="rhscl/s2i-core-rhel7" \
       version="1" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 ENV \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -2,9 +2,9 @@
 FROM rhel7
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
-    DESCRIPTION="Base image delivers all the essential tools needed for using source-to-image \
-and to allow using Software Collection packages. This image also defines default user \
-and includes some common scripts for derived images."
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible."
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL)
- follow recomended labels from Project Atomic Container best practices
- add summary and description labels - use ENV for simple using of same value in more descriptive labels
- remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)

+ update build scripts

@hhorak @pkubatrh @torsava Please take a look. Suggestions for values of SUMMARY/DESCRIPTION are welcomed.