### PR TITLE
Add rpm-file-permissions

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -27,8 +27,6 @@ ENV \
     HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH
 
-# Copy extra files to the image.
-COPY ./root/ /
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
@@ -54,10 +52,10 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   chown -R 1001:0 ${HOME}/.pki && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
-  yum clean all -y && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
-  chown -R 1001:0 /opt/app-root
+  yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.
@@ -65,3 +63,9 @@ WORKDIR ${HOME}
 
 ENTRYPOINT ["container-entrypoint"]
 CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default && \
+  chown -R 1001:0 /opt/app-root

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -33,9 +33,6 @@ ENV \
     HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH
 
-# Copy extra files to the image.
-COPY ./root/ /
-
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.
@@ -58,10 +55,10 @@ RUN INSTALL_PKGS="bsdtar \
   chown -R 1001:0 ${HOME}/.pki && \
   dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
-  dnf clean all -y && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
-  chown -R 1001:0 /opt/app-root
+  dnf clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.
@@ -69,3 +66,9 @@ WORKDIR ${HOME}
 
 ENTRYPOINT ["container-entrypoint"]
 CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default && \
+  chown -R 1001:0 /opt/app-root

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -29,9 +29,6 @@ ENV \
     HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Copy extra files to the image.
-COPY ./root/ /
-
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable
 # the SCL for all scripts without need to do 'scl enable'.
@@ -62,10 +59,10 @@ RUN yum repolist > /dev/null && \
   chown -R 1001:0 ${HOME}/.pki && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
-  yum clean all -y && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
-  chown -R 1001:0 /opt/app-root
+  yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.
@@ -73,3 +70,9 @@ WORKDIR ${HOME}
 
 ENTRYPOINT ["container-entrypoint"]
 CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default && \
+  chown -R 1001:0 /opt/app-root

--- a/core/root/usr/bin/rpm-file-permissions
+++ b/core/root/usr/bin/rpm-file-permissions
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+CHECK_DIRS="/ /opt /usr /usr/bin /usr/lib /usr/lib64"
+
+rpm_format="[%{FILESTATES:fstate}  %7{FILEMODES:octal} %{FILENAMES:shescape}\n]"
+
+rpm -q --qf "$rpm_format" filesystem | while read line
+do
+    eval "set -- $line"
+
+    case $1 in
+        normal) ;;
+        *) continue ;;
+    esac
+
+    case " $CHECK_DIRS " in
+        *" $3 "*)
+            chmod "${2: -4}" "$3"
+            ;;
+    esac
+done

--- a/core/root/usr/bin/rpm-file-permissions
+++ b/core/root/usr/bin/rpm-file-permissions
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CHECK_DIRS="/ /opt /usr /usr/bin /usr/lib /usr/lib64"
+CHECK_DIRS="/ /opt /etc /usr /usr/bin /usr/lib /usr/lib64"
 
 rpm_format="[%{FILESTATES:fstate}  %7{FILEMODES:octal} %{FILENAMES:shescape}\n]"
 

--- a/core/root/usr/bin/rpm-file-permissions
+++ b/core/root/usr/bin/rpm-file-permissions
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CHECK_DIRS="/ /opt /etc /usr /usr/bin /usr/lib /usr/lib64"
+CHECK_DIRS="/ /opt /etc /usr /usr/bin /usr/lib /usr/lib64 /usr/share /usr/libexec"
 
 rpm_format="[%{FILESTATES:fstate}  %7{FILEMODES:octal} %{FILENAMES:shescape}\n]"
 


### PR DESCRIPTION
As we are COPYing in some directories that are provided by the filesystem
rpm package we are unfortunately changing default permissions set on those
directories. This shell script uses information provided by an rpm query
to reset permissions of directories we are changing to their default values.

Fixes: rhbz#1481808