### PR TITLE
Change default shell to bash

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,6 +1,8 @@
 # This image is the base image for all s2i configurable Docker images.
 FROM centos:7
 
+SHELL ["/bin/bash", "-c"]
+
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \
 with all the tools needed to use source-to-image functionality while keeping \

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -1,6 +1,8 @@
 # This image is the base image for all s2i configurable Docker images.
 FROM registry.fedoraproject.org/fedora:26
 
+SHELL ["/bin/bash", "-c"]
+
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \
 with all the tools needed to use source-to-image functionality while keeping \

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -1,6 +1,8 @@
 # This image is the base image for all s2i configurable Docker images.
 FROM rhel7
 
+SHELL ["/bin/bash", "-c"]
+
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \
 with all the tools needed to use source-to-image functionality while keeping \


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/builder/#shell

-  This allows to run scl command directly in Dockerfile `RUN` (no need to wrap it in scripts with `#!/bin/bash` shebang)
- This does not fix `docker exec`

Fixes: https://github.com/sclorg/s2i-python-container/issues/226

@hhorak @praiskup @pkubatrh Please take a look.