### PR TITLE
Make option to control treatment of symbolic links in fix-permissions script adjustable

### DIFF
--- a/core/root/usr/bin/fix-permissions
+++ b/core/root/usr/bin/fix-permissions
@@ -3,6 +3,8 @@
 # Allow this script to fail without failing a build
 set +e
 
+SYMLINK_OPT=${2:--L}
+
 # Fix permissions on the given directory or file to allow group read/write of
 # regular files and execute of directories.
 
@@ -16,10 +18,10 @@ if ! [ -e "$1" ] ; then
   exit 0
 fi
 
-find -L "$1" ${CHECK_OWNER} \! -gid 0 -exec chgrp 0 {} +
-find -L "$1" ${CHECK_OWNER} \! -perm -g+rw -exec chmod g+rw {} +
-find -L "$1" ${CHECK_OWNER} -perm /u+x -a \! -perm /g+x -exec chmod g+x {} +
-find -L "$1" ${CHECK_OWNER} -type d \! -perm /g+x -exec chmod g+x {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} \! -gid 0 -exec chgrp 0 {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} \! -perm -g+rw -exec chmod g+rw {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} -perm /u+x -a \! -perm /g+x -exec chmod g+x {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} -type d \! -perm /g+x -exec chmod g+x {} +
 
 # Always end successfully
 exit 0


### PR DESCRIPTION
Following symlinks in fix-permissions script can sometimes make troubles. Example of issues that can occur is [here](https://bugzilla.redhat.com/show_bug.cgi?id=1536129). Let's make it possible to pass the option to script as a command line argument.