### PR TITLE
Install rsync in s2i-core to support 'oc rsync'

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -46,6 +46,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   findutils \
   gettext \
   groff-base \
+  rsync \
   scl-utils \
   tar \
   unzip \

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -41,6 +41,7 @@ RUN INSTALL_PKGS="bsdtar \
   findutils \
   gettext \
   groff-base \
+  rsync \
   tar \
   unzip" && \
   mkdir -p ${HOME}/.pki/nssdb && \

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -53,6 +53,7 @@ RUN prepare-yum-repositories && \
   findutils \
   gettext \
   groff-base \
+  rsync \
   scl-utils \
   tar \
   unzip \

--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -43,6 +43,7 @@ RUN INSTALL_PKGS="bsdtar \
   glibc-locale-source \
   glibc-all-langpacks \
   gettext \
+  rsync \
   scl-utils \
   tar \
   unzip \


### PR DESCRIPTION
Move `rsync` rpm package from s2i-base into s2i-core. Currently `rsync` is installed in s2i-base as dependency of `git`.

1. This packages is required for `oc rsync` command [1].

2. Also `rsync` could be used in `assemble` script - see sclorg/s2i-nodejs-container#182. Currently not all our images contains this package (sorry, I wasn't 100% precise about this when we discussed this)

All s2i-base based images contains `rsync` + mariadb, mysql, postgresql and mongodb images contain it. 

From s2i capable images - redis, cassandra, httpd, nginx and varnish don't have `rsync` installed. But IMHO redis and cassandra are database images, so `oc rsync` support should be same as in other database images. And installing `rsync` in remaining three images isn't big disadvantage (`403 k` size increase) + support for `oc rsync` is benefit.

If this PR is accepted, I'll remove `rsync` installation from mariadb, mysql, postgresql and mongodb in later PRs.

@pkubatrh @hhorak @praiskup Please take a look.






[1] https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html