### PR TITLE
Use nodejs v8 for having npm

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_SCL=rh-nodejs6
+    NODEJS_SCL=rh-nodejs8
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_SCL=rh-nodejs6
+    NODEJS_SCL=rh-nodejs8
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \


### PR DESCRIPTION
There are more reasons why we benefit from switching to latest version -- at least later EOL, and availability on more arches than x86_64 only.