### PR TITLE
Remove release label

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="s2i-base-container" \
       name="centos/s2i-base-centos7" \
       version="1" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # This is the list of basic dependencies that all language container image can

--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -9,7 +9,6 @@ functionality. Additionally, s2i-base also contains various libraries needed for
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
     NAME=s2i-base \
     VERSION=1 \
-    RELEASE=1 \
     ARCH=x86_64
 
 LABEL summary="$SUMMARY" \
@@ -19,8 +18,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # This is the list of basic dependencies that all language container image can

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -15,7 +15,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="s2i-core-container" \
       name="centos/s2i-core-centos7" \
       version="1" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 ENV \

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -7,7 +7,6 @@ with all the tools needed to use source-to-image functionality while keeping \
 the image size as small as possible." \
     NAME=s2i-core \
     VERSION=0 \
-    RELEASE=1 \
     ARCH=x86_64
 
 LABEL summary="$SUMMARY" \
@@ -19,8 +18,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
       usage="This image is supposed to be used as a base image for other images that support source-to-image" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 


### PR DESCRIPTION
Remove release label - not used in CentOS and in Fedora updated automtically by build system

Remove arch label - 'Optional: if omitted, it will be built for
all supported Fedora Architectures'

@pkubatrh Please take a look and merge.