### PR TITLE
Add  s2i-core-ubi7 Dockerfiles

### DIFF
--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -15,7 +15,8 @@ LABEL summary="$SUMMARY" \
       io.k8s.display-name="s2i base" \
       com.redhat.component="s2i-base-container" \
       name="rhscl/s2i-base-rhel7" \
-      version="1"
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 # This is the list of basic dependencies that all language container image can
 # consume.

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM rhel7
+FROM registry.access.redhat.com/ubi7:latest
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -14,7 +14,8 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url=image:///usr/libexec/s2i \
       com.redhat.component="s2i-core-container" \
       name="rhscl/s2i-core-rhel7" \
-      version="1"
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 ENV \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.


### PR DESCRIPTION
The dev preview images are available to public `registry.access.redhat.com/ubi8-dev-preview/ubi:latest`
It would be nice if this scl images are available. helps to showcase s2i app examples with this image.