### PR TITLE
Add s2i-core-ubi8 image

### DIFF
--- a/base/Dockerfile.rhel8
+++ b/base/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 # This image is the base image for all OpenShift v3 language container images.
-FROM rhel8/s2i-core
+FROM ubi8/s2i-core
 
 ENV SUMMARY="Base image with essential libraries and tools used as a base for \
 builder images like perl, python, ruby, etc." \
@@ -14,8 +14,9 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="s2i base" \
       com.redhat.component="s2i-base-container" \
-      name="rhel8/s2i-base" \
-      version="1"
+      name="ubi8/s2i-base" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 # This is the list of basic dependencies that all language container image can
 # consume.

--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -13,8 +13,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       io.s2i.scripts-url=image:///usr/libexec/s2i \
       com.redhat.component="s2i-core-container" \
-      name="rhel8/s2i-core" \
-      version="1"
+      name="ubi8/s2i-core" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 ENV \
     # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.

--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM rhel8-beta
+FROM registry.access.redhat.com/ubi8:latest
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \


### PR DESCRIPTION
The dev preview images are available to public registry.access.redhat.com/ubi8-dev-preview/ubi:latest
It would be nice if this scl images are available. helps to showcase s2i app examples with this image.

This PR is based on feedback from https://github.com/sclorg/s2i-base-container/pull/184#issuecomment-476081284
will wait for license issue to clear up to add ubi7 image.