### PR TITLE
clean yum cache in rhel8 based s2i-core

### DIFF
--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -52,9 +52,9 @@ RUN INSTALL_PKGS="bsdtar \
   yum" && \
   mkdir -p ${HOME}/.pki/nssdb && \
   chown -R 1001:0 ${HOME}/.pki && \
-  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
-  dnf clean all -y
+  yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.
 COPY ./root/ /


### PR DESCRIPTION
use yum instead of dnf as yum is now installed in the base image by default