### PR TITLE
centos8

### DIFF
--- a/base/Dockerfile.centos8
+++ b/base/Dockerfile.centos8
@@ -1,0 +1,49 @@
+# This image is the base image for all OpenShift v3 language container images.
+FROM centos/s2i-core-centos8
+
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
+    NODEJS_VER=10
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      com.redhat.component="s2i-base-container" \
+      name="centos8/s2i-base" \
+      version="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+RUN yum -y module enable nodejs:$NODEJS_VER && \
+  INSTALL_PKGS="autoconf \
+  automake \
+  bzip2 \
+  gcc-c++ \
+  gd-devel \
+  gdb \
+  git \
+  libcurl-devel \
+  libpq-devel \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  mariadb-connector-c-devel \
+  openssl-devel \
+  patch \
+  procps-ng \
+  npm \
+  sqlite-devel \
+  unzip \
+  wget \
+  which \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  yum -y clean all --enablerepo='*'

--- a/core/Dockerfile.centos8
+++ b/core/Dockerfile.centos8
@@ -1,0 +1,73 @@
+# This image is the base image for all s2i configurable container images.
+FROM centos:8
+
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.component="s2i-core-container" \
+      name="centos/s2i-core-centos8" \
+      version="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+ENV \
+    # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
+    STI_SCRIPTS_URL=image:///usr/libexec/s2i \
+    # Path to be used in other layers to place s2i scripts into
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PLATFORM="el8"
+
+# Copy just prepare-yum-repositories that is needed for packages install step,
+# other files might be added later so changing them does not cause packages
+# to be installed again, which takes long time
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+# Also setup the 'openshift' user that is used for the build execution and for the
+# application runtime execution.
+# TODO: Use better UID and GID values
+
+RUN INSTALL_PKGS="bsdtar \
+  findutils \
+  groff-base \
+  glibc-locale-source \
+  glibc-all-langpacks \
+  gettext \
+  rsync \
+  scl-utils \
+  tar \
+  unzip \
+  xz \
+  yum" && \
+  mkdir -p ${HOME}/.pki/nssdb && \
+  chown -R 1001:0 ${HOME}/.pki && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  yum -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT}


### PR DESCRIPTION
Dockerfiles for centos8. Derived from the rhel8 and centos7 files.

I have successfully made builds by changing the build and tag script to include centos8 dockerfiles.
@pkubatrh  @hhorak Sadly i am not sure about whether i can or should upgrade the common submodule that includes build.sh and tag.sh.

[modified_build_scripts.zip](https://github.com/sclorg/s2i-base-container/files/3741369/modified_build_scripts.zip)

I successfully built
https://hub.docker.com/r/jvonkoho/core
https://hub.docker.com/r/jvonkoho/base

and https://hub.docker.com/r/jvonkoho/python-36 which is working fine as replacement for centos/python-36-centos7
