### PR TITLE
Add missing packages redhat-rpm-config and glibc-langpack-en

### DIFF
--- a/base/Dockerfile.rhel8
+++ b/base/Dockerfile.rhel8
@@ -39,6 +39,7 @@ RUN yum -y module enable nodejs:$NODEJS_VER && \
   patch \
   procps-ng \
   npm \
+  redhat-rpm-config \
   sqlite-devel \
   unzip \
   wget \

--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="bsdtar \
   findutils \
   groff-base \
   glibc-locale-source \
-  glibc-all-langpacks \
+  glibc-langpack-en \
   gettext \
   rsync \
   scl-utils \


### PR DESCRIPTION
Add `redhat-rpm-config` package into `s2i-base` image
and replace `glibc-langpack-en` package instead `glibc-all-langpacks`
in `s2i-core` image

Reference to s2i-python-container issue: https://github.com/sclorg/s2i-python-container/pull/346

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>