### PR TITLE
Fix symlink from /usr/libexec/system-python to /usr/bin/python3

### DIFF
--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -54,7 +54,7 @@ RUN INSTALL_PKGS="bsdtar \
 COPY ./root/ /
 
 # Create a platform-python symlink if it does not exist already
-RUN [ -e /usr/libexec/platform-python ] || ln -s /usr/libexec/system-python /usr/libexec/platform-python
+RUN [ -e /usr/libexec/platform-python ] || ln -s /usr/bin/python3 /usr/libexec/platform-python
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.


### PR DESCRIPTION
Link /usr/libexec/platform-python is fixed. Now it references to /usr/bin/python3.

Required: s2i-ruby-container#248

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>