### PR TITLE
move core and base to fc31

### DIFF
--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -1,5 +1,5 @@
 # This image is the base image for all OpenShift v3 language container images.
-FROM registry.fedoraproject.org/f28/s2i-core:latest
+FROM registry.fedoraproject.org/f31/s2i-core:latest
 
 ENV SUMMARY="Base image with essential libraries and tools used as a base for \
 builder images like perl, python, ruby, etc." \
@@ -30,6 +30,7 @@ RUN INSTALL_PKGS="autoconf \
   gdb \
   git \
   libcurl-devel \
+  libpq-devel \
   libxml2-devel \
   libxslt-devel \
   lsof \
@@ -38,7 +39,6 @@ RUN INSTALL_PKGS="autoconf \
   npm \
   openssl-devel \
   patch \
-  postgresql-devel \
   procps-ng \
   sqlite-devel \
   unzip \

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM registry.fedoraproject.org/fedora:28
+FROM registry.fedoraproject.org/fedora:31
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \
@@ -40,6 +40,7 @@ ENV \
 RUN INSTALL_PKGS="bsdtar \
   findutils \
   gettext \
+  glibc-langpack-en \
   groff-base \
   rsync \
   tar \


### PR DESCRIPTION
install glibc-langpack-en as it was removed from fedora base image
use libpq-devel instead of postgresql-devel