### PR TITLE
Pull from registry.centos.org instead of (implicit) Docker Hub

### DIFF
--- a/core/Dockerfile.centos8
+++ b/core/Dockerfile.centos8
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM centos:8
+FROM registry.centos.org/centos/centos:8
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \


### PR DESCRIPTION
Bypasses the pull rate-limit.