### PR TITLE
Do not use symlink, but rather path from common

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -58,7 +58,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.
-COPY ./core/root/ /
+COPY ./common/shared-scripts/core/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.

--- a/core/Dockerfile.c9s
+++ b/core/Dockerfile.c9s
@@ -57,7 +57,7 @@ RUN INSTALL_PKGS="bsdtar \
   yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.
-COPY ./core/root/ /
+COPY ./common/shared-scripts/core/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.

--- a/core/Dockerfile.centos8
+++ b/core/Dockerfile.centos8
@@ -57,7 +57,7 @@ RUN INSTALL_PKGS="bsdtar \
   yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.
-COPY ./core/root/ /
+COPY ./common/shared-scripts/core/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -52,7 +52,7 @@ RUN INSTALL_PKGS="bsdtar \
   dnf clean all -y
 
 # Copy extra files to the image.
-COPY ./core/root/ /
+COPY ./common/shared-scripts/core/ /
 
 # Create a platform-python symlink if it does not exist already
 RUN [ -e /usr/libexec/platform-python ] || ln -s /usr/bin/python3 /usr/libexec/platform-python

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -65,7 +65,7 @@ RUN prepare-yum-repositories && \
   yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.
-COPY ./core/root/ /
+COPY ./common/shared-scripts/core/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.

--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -57,7 +57,7 @@ RUN INSTALL_PKGS="bsdtar \
   yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.
-COPY ./core/root/ /
+COPY ./common/shared-scripts/core/ /
 
 # Directory with the sources is set as the working directory so all STI scripts
 # can execute relative to this path.

--- a/core/root
+++ b/core/root
@@ -1,1 +1,0 @@
-../common/shared-scripts/core


### PR DESCRIPTION
During the building by GitHub Actions, the file /common/shared-scripts/core is not found.

This should fix the problem.

See error:

```bash
6 [internal] load build context
#6 transferring context: 87B done
#6 DONE 0.0s

#7 [3/5] COPY ./core/root/ /
#7 ERROR: "/common/shared-scripts/core": not found

#4 [1/5] FROM quay.io/centos/centos:stream9@sha256:28356bcd2b62bf775a344603d22c1d29c4a855ff4d4e853558ee72b20952ffb8
#4 resolve quay.io/centos/centos:stream9@sha256:28356bcd2b62bf775a344603d22c1d29c4a855ff4d4e853558ee72b20952ffb8 done
#4 sha256:6e0e003895ae89f80beb974738572d53516e97ff1503f572d37a4402cb2e7913 0B / 55.26MB
#4 DONE 0.0s

#5 [2/5] RUN INSTALL_PKGS="bsdtar   findutils   groff-base   glibc-locale-source   glibc-langpack-en   gettext   rsync   scl-utils   tar   unzip   xz   yum" &&   mkdir -p /opt/app-root/src/.pki/nssdb &&   chown -R 1001:0 /opt/app-root/src/.pki &&   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS &&   rpm -V $INSTALL_PKGS &&   yum -y clean all --enablerepo='*'
#5 CANCELED
```

The link is here: https://github.com/sclorg/s2i-base-container/runs/4776067753?check_suite_focus=true
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>