### PR TITLE
Use build-and-push-action from sclorg organization

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,7 +39,7 @@ jobs:
           dockerfile_path: "core"
           tag: ${{ matrix.tag }}
 
-      - name: Build and push s2i-core to quay.io registry
+      - name: Build and push s2i-base to quay.io registry
         uses: sclorg/build-and-push-action@v1
         with:
           registry: "quay.io"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # Schedule build to 1:00 each Tuesday
-    - cron: '0 1 * * 1-5'
+    - cron: '0 1 * * 2'
 jobs:
   build-and-push:
     name: Build and push s2i containers
@@ -17,107 +17,36 @@ jobs:
         include:
           - dockerfile: "Dockerfile"
             registry_namespace: "centos7"
-            registry_suffix: "-centos7"
             tag: "centos7"
+            quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
           - dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"
-            registry_suffix: "-c9s"
             tag: "c9s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Build and push s2i-core to quay.io registry
+        uses: sclorg/build-and-push-action@v1
         with:
-          fetch-depth: 0
-          submodules: true
-  
-      - name: Get base image name
-        id: base-image-name
-        run: |
-          # This command returns row with BASE_IMAGE_NAME
-          row=$(grep "BASE_IMAGE_NAME" Makefile)
-          # Return only base image name
-          BASE_IMAGE_ROW=${row/BASE_IMAGE_NAME = /}
-          echo ::set-output name=core_name::$BASE_IMAGE_ROW-core${{ matrix.registry_suffix }}
-          echo ::set-output name=base_name::$BASE_IMAGE_ROW-base${{ matrix.registry_suffix }}
+          registry: "quay.io"
+          registry_namespace: ${{ matrix.registry_namespace }}
+          registry_username: ${{ secrets[matrix.quayio_username] }}
+          registry_token: ${{ secrets[matrix.quayio_token] }}
+          dockerfile: ${{ matrix.dockerfile }}
+          docker_context: "core"
+          dockerfile_path: "core"
+          tag: ${{ matrix.tag }}
 
-      - name: Set current date as env variable
-        run: |
-          echo "NOW=$(date +'%Y%m%d')" >> $GITHUB_ENV
-
-      - name: Login to Quay.io private registry
-        if: ${{ matrix.registry_namespace != 'centos7' }}
-        uses: redhat-actions/podman-login@v1
+      - name: Build and push s2i-core to quay.io registry
+        uses: sclorg/build-and-push-action@v1
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
-          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
-
-      - name: Build s2i-core image
-        id: build-image-core
-        # https://github.com/marketplace/actions/buildah-build
-        uses: redhat-actions/buildah-build@v2
-        with:
-          dockerfiles: core/${{ matrix.dockerfile }}
-          image: ${{ steps.base-image-name.outputs.core_name }}
-          tags: latest ${{ matrix.tag }} ${{ env.NOW }}-${{ github.sha }}
-
-      - name: Push s2i-core CentOS 7 image to Quay.io
-        id: push-to-quay-core-centos7
-        if: ${{ matrix.registry_namespace == 'centos7' }}
-        uses: redhat-actions/push-to-registry@v2.2
-        with:
-          image: ${{ steps.build-image-core.outputs.image }}
-          tags: ${{ steps.build-image-core.outputs.tags }}
-          registry: quay.io/${{ matrix.registry_namespace }}
-          username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
-          password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
-
-      - name: Push s2i-core CentOS Stream 9 image to Quay.io
-        id: push-to-quay-core-c9s
-        if: ${{ matrix.registry_namespace != 'centos7' }}
-        uses: redhat-actions/push-to-registry@v2.2
-        with:
-          image: ${{ steps.build-image-core.outputs.image }}
-          tags: ${{ steps.build-image-core.outputs.tags }}
-          registry: quay.io/${{ matrix.registry_namespace }}
-          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
-          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN  }}
-
-      - name: Build s2i-base image
-        id: build-image-base
-        # https://github.com/marketplace/actions/buildah-build
-        uses: redhat-actions/buildah-build@v2
-        with:
-          dockerfiles: base/${{ matrix.dockerfile }}
-          image: ${{ steps.base-image-name.outputs.base_name }}
-          tags: latest ${{ matrix.tag }} ${{ env.NOW }}-${{ github.sha }}
-
-      - name: Push s2i-core CentOS 7 image to Quay.io
-        id: push-to-quay-base-centos7
-        if: ${{ matrix.registry_namespace == 'centos7' }}
-        uses: redhat-actions/push-to-registry@v2.2
-        with:
-          image: ${{ steps.build-image-base.outputs.image }}
-          tags: ${{ steps.build-image-base.outputs.tags }}
-          registry: quay.io/${{ matrix.registry_namespace }}
-          username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
-          password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
-
-      - name: Push s2i-core CentOS Stream 9 image to Quay.io
-        id: push-to-quay-base-c9s
-        if: ${{ matrix.registry_namespace != 'centos7' }}
-        uses: redhat-actions/push-to-registry@v2.2
-        with:
-          image: ${{ steps.build-image-base.outputs.image }}
-          tags: ${{ steps.build-image-base.outputs.tags }}
-          registry: quay.io/${{ matrix.registry_namespace }}
-          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
-          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN  }}
-
-      - name: Print image url
-        if: ${{ matrix.registry_namespace == 'centos7' }}
-        run: echo "Image pushed to ${{ steps.push-to-quay-core-centos7.outputs.registry-paths }} and ${{ steps.push-to-quay-base-centos7.outputs.registry-paths }}"
-
-      - name: Print image url
-        if: ${{ matrix.registry_namespace != 'centos7' }}
-        run: echo "Image pushed to ${{ steps.push-to-quay-core-c9s.outputs.registry-paths }} and ${{ steps.push-to-quay-base-c9s.outputs.registry-paths }}"
+          registry: "quay.io"
+          registry_namespace: ${{ matrix.registry_namespace }}
+          registry_username: ${{ secrets[matrix.quayio_username] }}
+          registry_token: ${{ secrets[matrix.quayio_token] }}
+          dockerfile: ${{ matrix.dockerfile }}
+          docker_context: "base"
+          dockerfile_path: "base"
+          tag: ${{ matrix.tag }}


### PR DESCRIPTION
Building and pushing s2i-base-container and s2i-core-container is done by build-and-push-action.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>