### PR TITLE
Add support for building and pushing to quay.io/fedora namespace

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -25,6 +25,11 @@ jobs:
             tag: "c9s"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+          - dockerfile: "Dockerfile.fedora"
+            registry_namespace: "fedora"
+            tag: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
 
     steps:
       - name: Build and push s2i-core to quay.io registry

--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -1,5 +1,5 @@
 # This image is the base image for all OpenShift v3 language container images.
-FROM registry.fedoraproject.org/f34/s2i-core:latest
+FROM quay.io/fedora/s2i-core-fedora:latest
 
 ENV SUMMARY="Base image with essential libraries and tools used as a base for \
 builder images like perl, python, ruby, etc." \

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM registry.fedoraproject.org/fedora:34
+FROM quay.io/fedora/fedora:34
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \


### PR DESCRIPTION
This pull request adds support for building and pushing s2i-core container
and s2i-base container into quay.io/fedora organization.

The repository for s2i-core-fedora container is already created. https://quay.io/repository/fedora/s2i-core-fedora
The repository for s2i-base-fedora container is already created. https://quay.io/repository/fedora/s2i-base-fedora

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>