### PR TITLE
Add support for building and testing s2i-core and s2i-base images on RHEL9 host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include common/common.mk
 # HACK: We need to build core first and tag it right after, so that base picks it up in the same run
 # We cannot just depend on tag here since tag depends on build
 base: core
-	echo "Building s2i-base container"
+	VERSIONS="base" $(script_env) $(build)
 
 core: core/root/help.1
 	VERSIONS="core" $(script_env) $(build)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ include common/common.mk
 # HACK: We need to build core first and tag it right after, so that base picks it up in the same run
 # We cannot just depend on tag here since tag depends on build
 base: core
+	echo "Building s2i-base container"
+
 core: core/root/help.1
 	VERSIONS="core" $(script_env) $(build)
 	VERSIONS="core" $(script_env) $(tag)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@ OpenShift base images
 
 [![Build and push images to Quay.io registry](https://github.com/sclorg/s2i-base-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/s2i-base-container/actions/workflows/build-and-push.yml)
 
-s2i-core-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/s2i-core-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/s2i-core-centos7)
-
-s2i-base-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/s2i-base-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/s2i-base-centos7)
+Images available on Quay are:
+* CentOS 7 [s2i-core](https://quay.io/repository/centos7/s2i-core-centos7)
+* CentOS 7 [s2i-base](https://quay.io/repository/centos7/s2i-base-centos7)
+* CentOS Stream 8 [s2i-core](https://quay.io/repository/sclorg/s2i-core-c8s)
+* CentOS Stream 8 [s2i-base](https://quay.io/repository/sclorg/s2i-base-c8s)
+* CentOS Stream 9 [s2i-core](https://quay.io/repository/sclorg/s2i-core-c9s)
+* CentOS Stream 9 [s2i-base](https://quay.io/repository/sclorg/s2i-base-c9s)
+* Fedora [s2i-core](https://quay.io/repository/fedora/s2i-core)
+* Fedora [s2i-base](https://quay.io/repository/fedora/s2i-base)
 
 This repository contains Dockerfiles which serve as base images for various OpenShift images.
 
@@ -17,6 +23,8 @@ s2i image versions currently provided are:
 
 RHEL versions currently supported are:
 * RHEL7
+* RHEL8
+* RHEL9
 
 CentOS versions currently supported are:
 * CentOS7

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -1,0 +1,49 @@
+# This image is the base image for all OpenShift v3 language container images.
+FROM ubi9/s2i-core
+
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
+    NODEJS_VER=14
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      com.redhat.component="s2i-base-container" \
+      name="ubi9/s2i-base" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+RUN INSTALL_PKGS="autoconf \
+  automake \
+  bzip2 \
+  gcc-c++ \
+  gd-devel \
+  gdb \
+  git \
+  libcurl-devel \
+  libpq-devel \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  mariadb-connector-c-devel \
+  openssl-devel \
+  patch \
+  procps-ng \
+  npm \
+  redhat-rpm-config \
+  sqlite-devel \
+  unzip \
+  wget \
+  which \
+  zlib-devel" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  yum -y clean all --enablerepo='*'

--- a/base/README.md
+++ b/base/README.md
@@ -103,5 +103,5 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-base-container.
 In that repository you also can find another variants of S2I base Dockerfiles.
 The Dockerfile for CentOS is called Dockerfile, the Dockerfile for RHEL7 is called Dockerfile.rhel7,
-the Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
+the Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile for RHEL9 is called Dockerfile.rhel9, the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s and the Dockerfile for Fedora is Dockerfile.fedora.

--- a/core/Dockerfile.rhel9
+++ b/core/Dockerfile.rhel9
@@ -1,0 +1,73 @@
+# This image is the base image for all s2i configurable container images.
+FROM registry.access.redhat.com/ubi9:latest
+
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.component="s2i-core-container" \
+      name="ubi9/s2i-core" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+ENV \
+    # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
+    STI_SCRIPTS_URL=image:///usr/libexec/s2i \
+    # Path to be used in other layers to place s2i scripts into
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PLATFORM="el9"
+
+# Copy just prepare-yum-repositories that is needed for packages install step,
+# other files might be added later so changing them does not cause packages
+# to be installed again, which takes long time
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+# Also setup the 'openshift' user that is used for the build execution and for the
+# application runtime execution.
+# TODO: Use better UID and GID values
+
+RUN INSTALL_PKGS="bsdtar \
+  findutils \
+  groff-base \
+  glibc-locale-source \
+  glibc-langpack-en \
+  gettext \
+  rsync \
+  scl-utils \
+  tar \
+  unzip \
+  xz \
+  yum" && \
+  mkdir -p ${HOME}/.pki/nssdb && \
+  chown -R 1001:0 ${HOME}/.pki && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  yum -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY ./core/root/ /
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT}

--- a/core/README.md
+++ b/core/README.md
@@ -84,5 +84,5 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-base-container.
 In that repository you also can find another variants of S2I Base Dockerfiles.
 The Dockerfile for CentOS is called Dockerfile, the Dockerfile for RHEL7 is called Dockerfile.rhel7,
-the Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
+the Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile for RHEL9 is called Dockerfile.rhel9, the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s and the Dockerfile for Fedora is Dockerfile.fedora.


### PR DESCRIPTION
Add support for building and testing s2i-core and s2i-base images on RHEL9 host

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>