### PR TITLE
build_and_push: detect fedora tag from Dockerfile

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,11 +37,23 @@ jobs:
             suffix: "c8s"
           - dockerfile: "Dockerfile.fedora"
             registry_namespace: "fedora"
-            tag: "36"
             quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
 
     steps:
+      - name: Automatic tag detection for Fedora images
+        id: tag
+        shell: bash
+        run: |
+          if [[ ${{ matrix.dockerfile }} == "Dockerfile.fedora" ]]
+          then
+            _version=`curl https://raw.githubusercontent.com/sclorg/s2i-base-container/master/core/Dockerfile.fedora | grep ^FROM`
+            _tag=`echo $_version | cut -d: -f2`
+          else
+            _tag=${{ matrix.tag }}
+          fi
+          echo "::set-output name=tag::${_tag}"
+
       - name: Build and push s2i-core to quay.io registry
         uses: sclorg/build-and-push-action@v2
         with:
@@ -52,7 +64,7 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           dockerfile_path: "core"
           suffix: ${{ matrix.suffix }}
-          tag: ${{ matrix.tag }}
+          tag: ${{ steps.tag.outputs.tag }}
 
       - name: Build and push s2i-base to quay.io registry
         uses: sclorg/build-and-push-action@v2
@@ -64,4 +76,4 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           dockerfile_path: "base"
           suffix: ${{ matrix.suffix }}
-          tag: ${{ matrix.tag }}
+          tag: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
Detect automatically fedora tag from Dockerfile in build_and_push_action.
The goal is to automatically detect change between Fedora version, e.g.,
35->36.

The only place, from where version transition can be spotted is
Dockerfile.fedora.

The used tag has to be in format "36".

curl for getting the Dockerfile.fedora was used because we do not have
repository cloned at that point in the action.
Cloning the whole repository because of one Dockerfile would be ineffective.

Should fix https://github.com/sclorg/build-and-push-action/issues/14.