### PR TITLE
install 'nodejs-npm' instead of 'npm' in fedora base image

### DIFF
--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -35,7 +35,7 @@ RUN INSTALL_PKGS="autoconf \
   lsof \
   make \
   mariadb-connector-c-devel \
-  npm \
+  nodejs-npm \
   openssl-devel \
   patch \
   procps-ng \


### PR DESCRIPTION
This is needed because of some adjustments in nodejs stack in Fedora which recently happened due to changes in node's modularity in Fedora.

If we install only 'npm' the verification of instalaltion fails as follows:

```
# dnf install -y npm
Installed:
  libuv-1:1.44.2-2.fc37.x86_64 nodejs-1:18.15.0-1.fc37.x86_64
  nodejs-docs-1:18.15.0-1.fc37.noarch nodejs-full-i18n-1:18.15.0-1.fc37.x86_64
  nodejs-libs-1:18.15.0-1.fc37.x86_64 nodejs-npm-1:9.5.0-1.18.15.0.1.fc37.x86_64

Complete!

#  rpm -V npm
package npm is not installed
# rpm -V nodejs-npm

```

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
