### PR TITLE
Use quay.io/centos/centos:centos7 base image instead of mirrors.centos.org

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM registry.centos.org/centos/centos:7
+FROM quay.io/centos/centos:centos7
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \


### PR DESCRIPTION
Let's use quay.io/centos/centos:centos7 base image instead of mirrors.centos.org

pulling image from mirrors.centos.org is failing with this reason:
```bash
-> Version core: building image from 'Dockerfile' ...
-> Pulling image registry.centos.org/centos/centos:7 before building image from Dockerfile.
Get https://registry.centos.org/v1/_ping: dial tcp: lookup registry.centos.org on 172.31.0.2:53: no such host
Pulling image registry.centos.org/centos/centos:7 failed.
Let's wait 5 seconds and try again.
Get https://registry.centos.org/v1/_ping: dial tcp: lookup registry.centos.org on 172.31.0.2:53: no such host
Pulling image regis
```

Quay.io should be more stable
