### PR TITLE
Add ARM64 support to c9s images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -61,7 +61,7 @@ jobs:
           dockerfile: "core/${{ matrix.dockerfile }}"
           image_name: "s2i-core${{ matrix.suffix }}"
           tag: ${{ steps.tag.outputs.tag }}
-          archs: amd64, ppc64le, s390x
+          archs: amd64, ppc64le, s390x, arm64
 
       - name: Check if dockerfile is not c9s , then build & push s2i-core to quay.io registry
         if: matrix.dockerfile != 'Dockerfile.c9s'


### PR DESCRIPTION
With ARM64 increasing market share, it makes sense to have native images for this platform too.