### PR TITLE
drop /sbin/nologin as default shell for default user

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -69,6 +69,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.c8s
+++ b/core/Dockerfile.c8s
@@ -64,6 +64,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.c9s
+++ b/core/Dockerfile.c9s
@@ -64,6 +64,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.f38
+++ b/core/Dockerfile.f38
@@ -66,6 +66,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.f39
+++ b/core/Dockerfile.f39
@@ -66,6 +66,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.rhel7
+++ b/core/Dockerfile.rhel7
@@ -76,6 +76,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -64,6 +64,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.rhel9
+++ b/core/Dockerfile.rhel9
@@ -64,6 +64,5 @@ CMD ["base-usage"]
 
 # Reset permissions of modified directories and add default user
 RUN rpm-file-permissions && \
-  useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT}


### PR DESCRIPTION
Only known use-cases not working when /sbin/nologin is set as default shell are:
1) executing $SHELL explicitly in already running container
2) explicitly running 'login' command when starting the container (e.g.,
   podman run --rm <imagename> login)
3) connecting to running container with 'exec login'
4) ssh-ing to container

And there is not any reason why these use-cases should not work in sclorg images.

The openshift runs the containers under random UID. In this case the default shell is /bin/sh. This removal thus should not change the behavior of the images run on openshift.

Further changes will be needed in images using NSS_WRAPPER and in micro images because the user is generated differently there.

Partly closes: https://github.com/sclorg/s2i-base-container/issues/283

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
