### PR TITLE
Switch using NodeJS from version 14 to version 20

### DIFF
--- a/base/Dockerfile.c8s
+++ b/base/Dockerfile.c8s
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_VER=14
+    NODEJS_VER=20
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -47,4 +47,5 @@ RUN yum -y module enable nodejs:$NODEJS_VER && \
   zlib-devel" && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
+  node -v | grep -qe "^v$NODEJS_VER\." && echo "Found VERSION $NODEJS_VER" && \
   yum -y clean all --enablerepo='*'

--- a/base/Dockerfile.c9s
+++ b/base/Dockerfile.c9s
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_VER=16
+    NODEJS_VER=20
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -20,7 +20,8 @@ LABEL summary="$SUMMARY" \
 
 # This is the list of basic dependencies that all language container image can
 # consume.
-RUN INSTALL_PKGS="nodejs autoconf \
+RUN yum -y module enable nodejs:$NODEJS_VER && \
+  INSTALL_PKGS="nodejs autoconf \
   automake \
   bzip2 \
   gcc-c++ \
@@ -46,4 +47,5 @@ RUN INSTALL_PKGS="nodejs autoconf \
   zlib-devel" && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
+  node -v | grep -qe "^v$NODEJS_VER\." && echo "Found VERSION $NODEJS_VER" && \
   yum -y clean all --enablerepo='*'

--- a/base/Dockerfile.rhel8
+++ b/base/Dockerfile.rhel8
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_VER=14
+    NODEJS_VER=20
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -47,4 +47,5 @@ RUN yum -y module enable nodejs:$NODEJS_VER && \
   zlib-devel" && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
+  node -v | grep -qe "^v$NODEJS_VER\." && echo "Found VERSION $NODEJS_VER" && \
   yum -y clean all --enablerepo='*'

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_VER=14
+    NODEJS_VER=20
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
@@ -46,4 +46,5 @@ RUN INSTALL_PKGS="autoconf \
   zlib-devel" && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
+  node -v | grep -qe "^v$NODEJS_VER\." && echo "Found VERSION $NODEJS_VER" && \
   yum -y clean all --enablerepo='*'

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -20,7 +20,8 @@ LABEL summary="$SUMMARY" \
 
 # This is the list of basic dependencies that all language container image can
 # consume.
-RUN INSTALL_PKGS="autoconf \
+RUN yum -y module enable nodejs:$NODEJS_VER && \
+  INSTALL_PKGS="autoconf \
   automake \
   bzip2 \
   gcc-c++ \


### PR DESCRIPTION
Switch using NodeJS from version 14 to version 20

NodeJS version 14 reached EOL and version 20
was already introduced.

Also Dockerfile's checks if node -v corresponds with RHEL8 and RHEL9 version

```bash
$ node -v 
v20
$
```
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
