### PR TITLE
add support for f40

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,6 +47,13 @@ jobs:
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             use_default_tags: 'false'
 
+          - dockerfile: "Dockerfile.f40"
+            registry_namespace: "fedora"
+            tag: "40"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            use_default_tags: 'false'
+
     steps:
       - name: Check if dockerfile is c9s , then build & push s2i-core for multi-arch
         if: matrix.dockerfile == 'Dockerfile.c9s'

--- a/base/Dockerfile.f40
+++ b/base/Dockerfile.f40
@@ -1,0 +1,48 @@
+FROM quay.io/fedora/s2i-core:40
+
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
+    NAME=s2i-base \
+    ARCH=x86_64
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      com.redhat.component="$NAME" \
+      name="fedora/$NAME" \
+      version="$VERSION" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+RUN INSTALL_PKGS="autoconf \
+  automake \
+  bzip2 \
+  gcc-c++ \
+  gd-devel \
+  gdb \
+  git \
+  libcurl-devel \
+  libpq-devel \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  mariadb-connector-c-devel \
+  nodejs-npm \
+  openssl-devel \
+  patch \
+  procps-ng \
+  sqlite-devel \
+  unzip \
+  wget \
+  which \
+  zlib-devel" && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf clean all -y

--- a/core/Dockerfile.f39
+++ b/core/Dockerfile.f39
@@ -6,7 +6,7 @@ ENV SUMMARY="Base image which allows using of source-to-image."	\
 with all the tools needed to use source-to-image functionality while keeping \
 the image size as small as possible." \
     NAME=s2i-core \
-    VERSION=38 \
+    VERSION=39 \
     ARCH=x86_64
 
 LABEL summary="$SUMMARY" \

--- a/core/Dockerfile.f40
+++ b/core/Dockerfile.f40
@@ -1,0 +1,70 @@
+# This image is the base image for all s2i configurable container images.
+FROM quay.io/fedora/fedora:40
+
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible." \
+    NAME=s2i-core \
+    VERSION=38 \
+    ARCH=x86_64
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.component="$NAME" \
+      name="fedora/$NAME" \
+      version="$VERSION" \
+      usage="This image is supposed to be used as a base image for other images that support source-to-image" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+ENV \
+    # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
+    STI_SCRIPTS_URL=image:///usr/libexec/s2i \
+    # Path to be used in other layers to place s2i scripts into
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
+    PLATFORM="fedora"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+# Also setup the 'openshift' user that is used for the build execution and for the
+# application runtime execution.
+# TODO: Use better UID and GID values
+RUN INSTALL_PKGS="bsdtar \
+  findutils \
+  gettext \
+  glibc-langpack-en \
+  groff-base \
+  rsync \
+  tar \
+  unzip" && \
+  mkdir -p ${HOME}/.pki/nssdb && \
+  chown -R 1001:0 ${HOME}/.pki && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf clean all -y
+
+# Copy extra files to the image.
+COPY ./core/root/ /
+
+# Create a platform-python symlink if it does not exist already
+RUN [ -e /usr/libexec/platform-python ] || ln -s /usr/bin/python3 /usr/libexec/platform-python
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.f40
+++ b/core/Dockerfile.f40
@@ -6,7 +6,7 @@ ENV SUMMARY="Base image which allows using of source-to-image."	\
 with all the tools needed to use source-to-image functionality while keeping \
 the image size as small as possible." \
     NAME=s2i-core \
-    VERSION=38 \
+    VERSION=40 \
     ARCH=x86_64
 
 LABEL summary="$SUMMARY" \


### PR DESCRIPTION
Start building and pushing to quay.io s2i-base and s2i-core images for f40.
We planned to support 2 Fedora version simultaneously, but this decision has been revised.
Only tested version is still f38.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
