### PR TITLE
Do not build s2i-core and s2i-base for F38.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -35,14 +35,6 @@ jobs:
             use_default_tags: 'true'
             arch: "amd64, ppc64le, s390x, arm64"
 
-          - dockerfile: "Dockerfile.f38"
-            registry_namespace: "fedora"
-            tag: "38"
-            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
-            use_default_tags: 'true'
-            arch: "amd64, ppc64le, s390x, arm64"
-
           - dockerfile: "Dockerfile.f39"
             registry_namespace: "fedora"
             tag: "39"


### PR DESCRIPTION

Do not build s2i-core and s2i-base for F38.
They reached EOL



<!-- issue-commentator = {"comment-id":"2247549868"} -->