### PR TITLE
CentOS Stream 10 is available on quay.io/centos/centos:stream10

### DIFF
--- a/core/Dockerfile.c10s
+++ b/core/Dockerfile.c10s
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM quay.io/centos/centos:stream10-development
+FROM quay.io/centos/centos:stream10
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \


### PR DESCRIPTION
CentOS Stream 10 is available on quay.io/centos/centos:stream10

Let's switch it.



<!-- issue-commentator = {"comment-id":"2519835352"} -->







































































<!-- testing-farm = {"lock":"false","comment-id":"2519840993","data":[{"id":"609d02c9-c91c-44f6-a473-6ecfd2612550","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":380.494186,"created":"2024-12-05T10:11:52.890974","updated":"2024-12-05T10:11:52.890981","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/609d02c9-c91c-44f6-a473-6ecfd2612550\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/609d02c9-c91c-44f6-a473-6ecfd2612550/pipeline.log\">pipeline</a>"]},{"id":"1fe1dcdf-88fe-47a6-9519-584b1519ca34","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":390.652943,"created":"2024-12-05T10:11:55.564576","updated":"2024-12-05T10:11:55.564583","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1fe1dcdf-88fe-47a6-9519-584b1519ca34\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1fe1dcdf-88fe-47a6-9519-584b1519ca34/pipeline.log\">pipeline</a>"]},{"id":"8ac76792-a8df-4258-b94f-eb7ae54dbe67","name":"CentOS Stream 9 - core","status":"complete","outcome":"passed","runTime":317.45607,"created":"2024-12-05T10:05:24.327621","updated":"2024-12-05T10:05:24.327627","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8ac76792-a8df-4258-b94f-eb7ae54dbe67\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8ac76792-a8df-4258-b94f-eb7ae54dbe67/pipeline.log\">pipeline</a>"]},{"id":"dcc5540b-25d4-4d01-9ef1-d41f1f6cb575","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":314.98167,"created":"2024-12-05T10:11:54.070071","updated":"2024-12-05T10:11:54.070078","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dcc5540b-25d4-4d01-9ef1-d41f1f6cb575\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dcc5540b-25d4-4d01-9ef1-d41f1f6cb575/pipeline.log\">pipeline</a>"]},{"id":"fea61613-a10b-4c59-ba1c-01a322f9e968","name":"Fedora - base","status":"complete","outcome":"passed","runTime":401.422017,"created":"2024-12-05T10:11:53.111522","updated":"2024-12-05T10:11:53.111530","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fea61613-a10b-4c59-ba1c-01a322f9e968\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fea61613-a10b-4c59-ba1c-01a322f9e968/pipeline.log\">pipeline</a>"]},{"id":"2e9e531a-018f-4bfa-8832-de6d17d75ef3","name":"Fedora - core","status":"complete","outcome":"passed","runTime":492.218389,"created":"2024-12-05T10:11:52.911087","updated":"2024-12-05T10:11:52.911095","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2e9e531a-018f-4bfa-8832-de6d17d75ef3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2e9e531a-018f-4bfa-8832-de6d17d75ef3/pipeline.log\">pipeline</a>"]},{"id":"e74a2e8e-f9dc-4066-b459-4b4d9a37aa67","name":"RHEL9 - base","status":"complete","outcome":"passed","runTime":833.088932,"created":"2024-12-05T10:11:53.358689","updated":"2024-12-05T10:11:53.358696","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e74a2e8e-f9dc-4066-b459-4b4d9a37aa67\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e74a2e8e-f9dc-4066-b459-4b4d9a37aa67/pipeline.log\">pipeline</a>"]},{"id":"7f16de61-6d54-42ae-9b26-9c5f472e81e8","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":869.125765,"created":"2024-12-05T10:11:52.539755","updated":"2024-12-05T10:11:52.539762","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f16de61-6d54-42ae-9b26-9c5f472e81e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f16de61-6d54-42ae-9b26-9c5f472e81e8/pipeline.log\">pipeline</a>"]},{"id":"0e632c5b-9dd1-425c-a4fd-1eb35a8863ab","name":"RHEL8 - core","status":"complete","outcome":"passed","runTime":992.638925,"created":"2024-12-05T10:11:54.546381","updated":"2024-12-05T10:11:54.546388","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e632c5b-9dd1-425c-a4fd-1eb35a8863ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e632c5b-9dd1-425c-a4fd-1eb35a8863ab/pipeline.log\">pipeline</a>"]},{"id":"87bc2faf-9afa-4a6f-ab11-e9f19552f7bb","name":"RHEL8 - base","runTime":1058.347267,"created":"2024-12-05T10:11:53.676546","updated":"2024-12-05T10:11:53.676553","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87bc2faf-9afa-4a6f-ab11-e9f19552f7bb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87bc2faf-9afa-4a6f-ab11-e9f19552f7bb/pipeline.log\">pipeline</a>"]}]} -->