### PR TITLE
Enable testing s2i-core and s2i-base container on RHEL10

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s", "rhel10" ]
         version: [ "core", "base" ]
 
     if: |


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"2582562252"} -->

























































<!-- testing-farm = {"lock":"false","comment-id":"2582576608","data":[{"id":"5c0a7723-a9a1-4032-b465-ef6f1d157716","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":408.512902,"created":"2025-01-10T12:08:26.490760","updated":"2025-01-10T12:08:26.490770","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5c0a7723-a9a1-4032-b465-ef6f1d157716\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5c0a7723-a9a1-4032-b465-ef6f1d157716/pipeline.log\">pipeline</a>"]},{"id":"432b42ef-9ee1-4215-83ff-913fbf9b025c","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":404.644333,"created":"2025-01-10T12:08:28.845558","updated":"2025-01-10T12:08:28.845566","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/432b42ef-9ee1-4215-83ff-913fbf9b025c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/432b42ef-9ee1-4215-83ff-913fbf9b025c/pipeline.log\">pipeline</a>"]},{"id":"53527ebc-c877-4192-8ee3-e48586a8ef01","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":474.200134,"created":"2025-01-10T12:08:28.646298","updated":"2025-01-10T12:08:28.646306","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/53527ebc-c877-4192-8ee3-e48586a8ef01\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/53527ebc-c877-4192-8ee3-e48586a8ef01/pipeline.log\">pipeline</a>"]},{"id":"b98c85cb-9591-4a30-b9b9-d714e6739a2b","name":"Fedora - base","status":"complete","outcome":"passed","runTime":621.03746,"created":"2025-01-10T12:08:25.910774","updated":"2025-01-10T12:08:25.910783","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b98c85cb-9591-4a30-b9b9-d714e6739a2b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b98c85cb-9591-4a30-b9b9-d714e6739a2b/pipeline.log\">pipeline</a>"]},{"id":"05e712af-d867-4eab-93e5-bdfe760f01bb","name":"Fedora - core","status":"complete","outcome":"passed","runTime":619.581621,"created":"2025-01-10T12:08:26.631586","updated":"2025-01-10T12:08:26.631594","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/05e712af-d867-4eab-93e5-bdfe760f01bb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/05e712af-d867-4eab-93e5-bdfe760f01bb/pipeline.log\">pipeline</a>"]},{"id":"b4bd98d4-f09a-4c02-9ab4-5d687c64aa14","name":"RHEL9 - base","status":"complete","outcome":"passed","runTime":763.825095,"created":"2025-01-10T12:08:27.679716","updated":"2025-01-10T12:08:27.679726","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4bd98d4-f09a-4c02-9ab4-5d687c64aa14\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4bd98d4-f09a-4c02-9ab4-5d687c64aa14/pipeline.log\">pipeline</a>"]},{"id":"d430f16a-1680-47ba-b4f8-3ac95a622417","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":925.520595,"created":"2025-01-10T12:08:26.676098","updated":"2025-01-10T12:08:26.676104","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d430f16a-1680-47ba-b4f8-3ac95a622417\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d430f16a-1680-47ba-b4f8-3ac95a622417/pipeline.log\">pipeline</a>"]},{"id":"b207ff60-9d38-4025-b403-8ddff960c0c6","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":970.028708,"created":"2025-01-10T12:08:28.722452","updated":"2025-01-10T12:08:28.722461","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b207ff60-9d38-4025-b403-8ddff960c0c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b207ff60-9d38-4025-b403-8ddff960c0c6/pipeline.log\">pipeline</a>"]},{"id":"ec7913aa-efdc-4d47-aeaf-885967a75d55","name":"CentOS Stream 9 - core","runTime":572.631996,"created":"2025-01-10T12:22:59.825452","updated":"2025-01-10T12:22:59.825459","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/ec7913aa-efdc-4d47-aeaf-885967a75d55\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ec7913aa-efdc-4d47-aeaf-885967a75d55/pipeline.log\">pipeline</a>"]}]} -->