### PR TITLE
Testing, building RHEL10 container-images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ s2i image versions currently provided are:
 RHEL versions currently supported are:
 * RHEL8
 * RHEL9
+* RHEL10
 
 CentOS versions currently supported are:
 * CentOS Stream 9

--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -1,0 +1,52 @@
+# This image is the base image for all OpenShift v3 language container images.
+FROM ubi10/s2i-core
+
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
+    NODEJS_VER=22 \
+    NAME=s2i-base
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      io.openshift.tags="s2i-base rhel10" \
+      com.redhat.component="s2i-base-container" \
+      name="ubi10/s2i-base" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+RUN INSTALL_PKGS="autoconf \
+  automake \
+  bzip2 \
+  gcc-c++ \
+  gd-devel \
+  gdb \
+  git \
+  libcurl-devel \
+  libpq-devel \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  mariadb-connector-c-devel \
+  openssl-devel \
+  patch \
+  procps-ng \
+  nodejs-npm \
+  redhat-rpm-config \
+  sqlite-devel \
+  unzip \
+  wget \
+  which \
+  zlib-ng-compat-devel" && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  node -v | grep -qe "^v$NODEJS_VER\." && echo "Found VERSION $NODEJS_VER" && \
+  dnf -y clean all --enablerepo='*'

--- a/base/README.md
+++ b/base/README.md
@@ -103,5 +103,6 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-base-container.
 In that repository you also can find another variants of S2I base Dockerfiles.
 The Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s, the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is Dockerfile.fedora.

--- a/core/Dockerfile.rhel10
+++ b/core/Dockerfile.rhel10
@@ -1,0 +1,68 @@
+# This image is the base image for all s2i configurable container images.
+FROM registry.stage.redhat.io/ubi10:latest
+
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible." \
+    NAME=s2i-core \
+    VERSION=10
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.openshift.tags="s2i-core rhel10" \
+      com.redhat.component="s2i-core-container" \
+      name="ubi10/s2i-core" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+ENV \
+    # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
+    STI_SCRIPTS_URL=image:///usr/libexec/s2i \
+    # Path to be used in other layers to place s2i scripts into
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PLATFORM="el10"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+# Also setup the 'openshift' user that is used for the build execution and for the
+# application runtime execution.
+# TODO: Use better UID and GID values
+
+RUN INSTALL_PKGS="bsdtar \
+  findutils \
+  gettext \
+  glibc-langpack-en \
+  groff-base \
+  rsync \
+  tar \
+  unzip \
+  yum" && \
+  mkdir -p ${HOME}/.pki/nssdb && \
+  chown -R 1001:0 ${HOME}/.pki && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY ./core/root/ /
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.rhel10
+++ b/core/Dockerfile.rhel10
@@ -1,5 +1,5 @@
 # This image is the base image for all s2i configurable container images.
-FROM registry.stage.redhat.io/ubi10:latest
+FROM ubi10:latest
 
 ENV SUMMARY="Base image which allows using of source-to-image."	\
     DESCRIPTION="The s2i-core image provides any images layered on top of it \

--- a/core/README.md
+++ b/core/README.md
@@ -84,5 +84,6 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-base-container.
 In that repository you also can find another variants of S2I Base Dockerfiles.
 The Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s, the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is Dockerfile.fedora.


### PR DESCRIPTION
This pull request enables building and testing RHEL10 container images
for `base` and `core` version.



<!-- issue-commentator = {"comment-id":"2586991751"} -->





















































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2587008183","data":[{"id":"2ae042f1-9f38-4a9c-ad19-e459c8930784","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":359.846077,"created":"2025-01-29T12:15:31.326894","updated":"2025-01-29T12:15:31.326902","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2ae042f1-9f38-4a9c-ad19-e459c8930784\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2ae042f1-9f38-4a9c-ad19-e459c8930784/pipeline.log\">pipeline</a>"]},{"id":"49c55e32-8b64-401f-a6fd-ed416d760285","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":360.494931,"created":"2025-01-29T12:15:32.091937","updated":"2025-01-29T12:15:32.091943","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/49c55e32-8b64-401f-a6fd-ed416d760285\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/49c55e32-8b64-401f-a6fd-ed416d760285/pipeline.log\">pipeline</a>"]},{"id":"bea51591-5c60-48a8-81c5-26dd583c0efc","name":"CentOS Stream 9 - core","status":"complete","outcome":"passed","runTime":445.567755,"created":"2025-01-29T12:15:31.385422","updated":"2025-01-29T12:15:31.385435","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bea51591-5c60-48a8-81c5-26dd583c0efc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bea51591-5c60-48a8-81c5-26dd583c0efc/pipeline.log\">pipeline</a>"]},{"id":"06b83011-3aee-43d6-860e-eddf2de635f2","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":498.741464,"created":"2025-01-29T12:15:33.482759","updated":"2025-01-29T12:15:33.482768","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/06b83011-3aee-43d6-860e-eddf2de635f2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/06b83011-3aee-43d6-860e-eddf2de635f2/pipeline.log\">pipeline</a>"]},{"id":"cb49ebec-1f10-45ea-9e57-6acfce43f12e","name":"Fedora - core","status":"complete","outcome":"passed","runTime":548.8961,"created":"2025-01-29T12:15:33.378096","updated":"2025-01-29T12:15:33.378103","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cb49ebec-1f10-45ea-9e57-6acfce43f12e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cb49ebec-1f10-45ea-9e57-6acfce43f12e/pipeline.log\">pipeline</a>"]},{"id":"5f443415-1e4e-419e-ba21-6101a0d31fdf","name":"Fedora - base","status":"complete","outcome":"passed","runTime":533.816062,"created":"2025-01-29T12:15:33.392700","updated":"2025-01-29T12:15:33.392709","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5f443415-1e4e-419e-ba21-6101a0d31fdf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5f443415-1e4e-419e-ba21-6101a0d31fdf/pipeline.log\">pipeline</a>"]},{"id":"43f8f925-70ba-44d2-990e-20951c226af7","name":"RHEL9 - base","status":"complete","outcome":"passed","runTime":826.267628,"created":"2025-01-29T12:15:33.169717","updated":"2025-01-29T12:15:33.169725","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/43f8f925-70ba-44d2-990e-20951c226af7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/43f8f925-70ba-44d2-990e-20951c226af7/pipeline.log\">pipeline</a>"]},{"id":"2ef84d7c-412c-4473-90d5-4b24eb008239","name":"RHEL10 - core","status":"complete","outcome":"passed","runTime":855.140908,"created":"2025-01-29T12:15:31.391965","updated":"2025-01-29T12:15:31.391974","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ef84d7c-412c-4473-90d5-4b24eb008239\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ef84d7c-412c-4473-90d5-4b24eb008239/pipeline.log\">pipeline</a>"]},{"id":"f8892a4f-aa83-4c25-9e7c-9223bd527014","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":808.56911,"created":"2025-01-29T12:15:31.243543","updated":"2025-01-29T12:15:31.243553","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8892a4f-aa83-4c25-9e7c-9223bd527014\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8892a4f-aa83-4c25-9e7c-9223bd527014/pipeline.log\">pipeline</a>"]},{"id":"a2d4a88e-ca20-4268-9ae6-34b8c92fb44d","name":"RHEL10 - base","status":"complete","outcome":"passed","runTime":802.240495,"created":"2025-01-29T12:15:31.225359","updated":"2025-01-29T12:15:31.225369","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2d4a88e-ca20-4268-9ae6-34b8c92fb44d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2d4a88e-ca20-4268-9ae6-34b8c92fb44d/pipeline.log\">pipeline</a>"]},{"id":"6a8b924d-b267-4fd3-82df-dea793bf35b6","name":"RHEL8 - core","runTime":1025.363528,"created":"2025-01-29T12:15:32.386701","updated":"2025-01-29T12:15:32.386708","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6a8b924d-b267-4fd3-82df-dea793bf35b6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6a8b924d-b267-4fd3-82df-dea793bf35b6/pipeline.log\">pipeline</a>"]},{"id":"ef9e0156-3d89-4b82-9685-19855604e27e","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":974.41859,"created":"2025-01-29T12:15:31.477922","updated":"2025-01-29T12:15:31.477931","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef9e0156-3d89-4b82-9685-19855604e27e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef9e0156-3d89-4b82-9685-19855604e27e/pipeline.log\">pipeline</a>"]}]} -->