### PR TITLE
New Fedora F42 base and core images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -59,6 +59,14 @@ jobs:
             use_default_tags: 'false'
             arch: "amd64, ppc64le, s390x, arm64"
 
+          - dockerfile: "Dockerfile.f42"
+            registry_namespace: "fedora"
+            tag: "42"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            use_default_tags: 'false'
+            arch: "amd64, ppc64le, s390x, arm64"
+
     steps:
       - name: Build and push s2i-core to quay.io registry
         uses: sclorg/build-and-push-action@v4

--- a/base/Dockerfile.f42
+++ b/base/Dockerfile.f42
@@ -1,0 +1,48 @@
+FROM quay.io/fedora/s2i-core:42
+
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
+    NAME=s2i-base \
+    ARCH=x86_64
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      com.redhat.component="$NAME" \
+      name="fedora/$NAME" \
+      version="$VERSION" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+RUN INSTALL_PKGS="autoconf \
+  automake \
+  bzip2 \
+  gcc-c++ \
+  gd-devel \
+  gdb \
+  git \
+  libcurl-devel \
+  libpq-devel \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  mariadb-connector-c-devel \
+  nodejs-npm \
+  openssl-devel \
+  patch \
+  procps-ng \
+  sqlite-devel \
+  unzip \
+  wget2 \
+  which \
+  zlib-ng-compat-devel" && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf clean all -y

--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -1,1 +1,1 @@
-Dockerfile.f41
+Dockerfile.f42

--- a/core/Dockerfile.f42
+++ b/core/Dockerfile.f42
@@ -1,0 +1,71 @@
+# This image is the base image for all s2i configurable container images.
+FROM quay.io/fedora/fedora:42
+
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible." \
+    NAME=s2i-core \
+    VERSION=42 \
+    ARCH=x86_64
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.component="$NAME" \
+      name="fedora/$NAME" \
+      version="$VERSION" \
+      usage="This image is supposed to be used as a base image for other images that support source-to-image" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+ENV \
+    # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
+    STI_SCRIPTS_URL=image:///usr/libexec/s2i \
+    # Path to be used in other layers to place s2i scripts into
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
+    PLATFORM="fedora"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+# Also setup the 'openshift' user that is used for the build execution and for the
+# application runtime execution.
+# TODO: Use better UID and GID values
+RUN INSTALL_PKGS="bsdtar \
+  findutils \
+  gettext \
+  glibc-langpack-en \
+  groff-base \
+  python3 \
+  rsync \
+  tar \
+  unzip" && \
+  mkdir -p ${HOME}/.pki/nssdb && \
+  chown -R 1001:0 ${HOME}/.pki && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf clean all -y
+
+# Copy extra files to the image.
+COPY ./core/root/ /
+
+# Create a platform-python symlink if it does not exist already
+RUN [ -e /usr/libexec/platform-python ] || ln -s /usr/bin/python3 /usr/libexec/platform-python
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -1,1 +1,1 @@
-Dockerfile.f41
+Dockerfile.f42


### PR DESCRIPTION
As Fedora 42 is out and fedora image is present in quay.io/fedora/fedora:42

Let's move our Fedora s2i-base-container to the newest one.

<!-- issue-commentator = {"comment-id":"2809641548"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2809673600","data":[{"id":"bd9450d2-5249-47fc-bff0-b06aeb17321f","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":291.308437,"created":"2025-04-16T13:50:33.430971","updated":"2025-04-16T13:50:33.430977","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bd9450d2-5249-47fc-bff0-b06aeb17321f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bd9450d2-5249-47fc-bff0-b06aeb17321f/pipeline.log\">pipeline</a>"]},{"id":"49848b5e-f820-4f8b-aa39-ea68f36a6dd1","name":"CentOS Stream 9 - core","status":"complete","outcome":"passed","runTime":351.745246,"created":"2025-04-22T11:17:33.553385","updated":"2025-04-22T11:17:33.553392","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/49848b5e-f820-4f8b-aa39-ea68f36a6dd1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/49848b5e-f820-4f8b-aa39-ea68f36a6dd1/pipeline.log\">pipeline</a>"]},{"id":"c315e128-b719-4235-a314-dac212c0ae1b","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":378.987822,"created":"2025-04-22T11:17:33.286763","updated":"2025-04-22T11:17:33.286770","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c315e128-b719-4235-a314-dac212c0ae1b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c315e128-b719-4235-a314-dac212c0ae1b/pipeline.log\">pipeline</a>"]},{"id":"2f856231-1384-4abf-9668-d7fd39cf0252","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":331.631722,"created":"2025-04-22T11:17:33.462685","updated":"2025-04-22T11:17:33.462693","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2f856231-1384-4abf-9668-d7fd39cf0252\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2f856231-1384-4abf-9668-d7fd39cf0252/pipeline.log\">pipeline</a>"]},{"id":"28897c5c-df49-47d8-84b9-7c559b6e6cf8","name":"Fedora - base","status":"complete","outcome":"passed","runTime":401.624094,"created":"2025-04-22T11:17:33.011721","updated":"2025-04-22T11:17:33.011726","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/28897c5c-df49-47d8-84b9-7c559b6e6cf8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/28897c5c-df49-47d8-84b9-7c559b6e6cf8/pipeline.log\">pipeline</a>"]},{"id":"2d551c6b-2d64-407a-a769-2c28d2da09d5","name":"Fedora - core","status":"complete","outcome":"passed","runTime":400.441423,"created":"2025-04-22T11:17:32.412592","updated":"2025-04-22T11:17:32.412599","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2d551c6b-2d64-407a-a769-2c28d2da09d5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2d551c6b-2d64-407a-a769-2c28d2da09d5/pipeline.log\">pipeline</a>"]},{"id":"afc8ca78-b17a-421d-9248-e0cec9c3f4d6","name":"RHEL10 - base","status":"complete","outcome":"passed","runTime":907.781897,"created":"2025-04-22T11:17:35.036471","updated":"2025-04-22T11:17:35.036476","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/afc8ca78-b17a-421d-9248-e0cec9c3f4d6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/afc8ca78-b17a-421d-9248-e0cec9c3f4d6/pipeline.log\">pipeline</a>"]},{"id":"9713cd8a-972c-4c6c-b1df-fb59050f23be","name":"RHEL10 - core","status":"complete","outcome":"passed","runTime":878.540184,"created":"2025-04-22T11:17:33.647834","updated":"2025-04-22T11:17:33.647840","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9713cd8a-972c-4c6c-b1df-fb59050f23be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9713cd8a-972c-4c6c-b1df-fb59050f23be/pipeline.log\">pipeline</a>"]},{"id":"4cf38bb8-9de0-41fa-b6be-70dbf30f76a0","name":"RHEL9 - base","status":"complete","outcome":"passed","runTime":1035.14481,"created":"2025-04-22T11:17:33.301546","updated":"2025-04-22T11:17:33.301552","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4cf38bb8-9de0-41fa-b6be-70dbf30f76a0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4cf38bb8-9de0-41fa-b6be-70dbf30f76a0/pipeline.log\">pipeline</a>"]},{"id":"576b8938-5e28-4b7a-8e94-dd1cad34625a","name":"RHEL8 - core","runTime":1070.066964,"created":"2025-04-22T11:17:32.999198","updated":"2025-04-22T11:17:32.999204","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/576b8938-5e28-4b7a-8e94-dd1cad34625a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/576b8938-5e28-4b7a-8e94-dd1cad34625a/pipeline.log\">pipeline</a>"]},{"id":"ec2b8630-209d-483a-b1c1-93382b6a1ab2","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":1041.775841,"created":"2025-04-22T11:17:34.533443","updated":"2025-04-22T11:17:34.533448","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec2b8630-209d-483a-b1c1-93382b6a1ab2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec2b8630-209d-483a-b1c1-93382b6a1ab2/pipeline.log\">pipeline</a>"]},{"id":"987d6499-92b3-4cd2-abfe-acdf05a0695a","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":1021.413491,"created":"2025-04-22T11:17:32.795995","updated":"2025-04-22T11:17:32.796000","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/987d6499-92b3-4cd2-abfe-acdf05a0695a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/987d6499-92b3-4cd2-abfe-acdf05a0695a/pipeline.log\">pipeline</a>"]}]} -->