### PR TITLE
Move GitHub Actions to run from ubuntu-20.04 to ubuntu-latest.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -12,7 +12,7 @@ jobs:
     # To not run in forks
     if: github.repository_owner == 'sclorg'
     name: Build and push s2i containers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: "Container tests: ${{ matrix.version }} - ${{ matrix.os_test }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: container-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
       cancel-in-progress: true


### PR DESCRIPTION
Move GitHub Actions to run from ubuntu-20.04 to ubuntu-latest.
ubuntu-20.04 reached EOL and it is not supported at all in GitHub Actions

<!-- issue-commentator = {"comment-id":"2809655058"} -->