### PR TITLE
Move to more recent Node.js version to not miss EOL

### DIFF
--- a/base/Dockerfile.c9s
+++ b/base/Dockerfile.c9s
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_VER=20 \
+    NODEJS_VER=22 \
     NAME=s2i-base
 
 LABEL summary="$SUMMARY" \

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -7,7 +7,7 @@ builder images like perl, python, ruby, etc." \
 images layered on top of it with all the tools needed to use source-to-image \
 functionality. Additionally, s2i-base also contains various libraries needed for \
 it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
-    NODEJS_VER=20
+    NODEJS_VER=22
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"2959408901"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2959436694","data":[{"id":"c6b13f5c-7b3a-4e2e-a82b-205e5700ed80","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":301.933017,"created":"2025-06-30T11:40:05.041014","updated":"2025-06-30T11:40:05.041020","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c6b13f5c-7b3a-4e2e-a82b-205e5700ed80\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c6b13f5c-7b3a-4e2e-a82b-205e5700ed80/pipeline.log\">pipeline</a>"]},{"id":"3f5103c9-1a38-4982-8d2a-951144ee6da1","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":261.486251,"created":"2025-06-30T11:40:05.021429","updated":"2025-06-30T11:40:05.021437","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3f5103c9-1a38-4982-8d2a-951144ee6da1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3f5103c9-1a38-4982-8d2a-951144ee6da1/pipeline.log\">pipeline</a>"]},{"id":"275c872e-ff39-45aa-a559-2de516f96d6f","name":"Fedora - base","status":"complete","outcome":"passed","runTime":379.871472,"created":"2025-06-30T11:40:04.934539","updated":"2025-06-30T11:40:04.934546","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/275c872e-ff39-45aa-a559-2de516f96d6f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/275c872e-ff39-45aa-a559-2de516f96d6f/pipeline.log\">pipeline</a>"]},{"id":"b364b20d-3883-4f8b-a6c8-9796a71773d4","name":"Fedora - core","status":"complete","outcome":"passed","runTime":372.222453,"created":"2025-06-30T11:40:06.328034","updated":"2025-06-30T11:40:06.328042","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b364b20d-3883-4f8b-a6c8-9796a71773d4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b364b20d-3883-4f8b-a6c8-9796a71773d4/pipeline.log\">pipeline</a>"]},{"id":"17ba31b4-4d63-4906-9a69-8744bbd603f6","name":"CentOS Stream 9 - core","status":"complete","outcome":"passed","runTime":302.788129,"created":"2025-06-10T14:18:28.612724","updated":"2025-06-10T14:18:28.612733","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/17ba31b4-4d63-4906-9a69-8744bbd603f6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/17ba31b4-4d63-4906-9a69-8744bbd603f6/pipeline.log\">pipeline</a>"]},{"id":"1141a875-c4bf-4d5a-9e9a-4fce5aba5f11","name":"RHEL10 - core","status":"complete","outcome":"passed","runTime":789.111134,"created":"2025-06-30T11:40:07.022428","updated":"2025-06-30T11:40:07.022433","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1141a875-c4bf-4d5a-9e9a-4fce5aba5f11\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1141a875-c4bf-4d5a-9e9a-4fce5aba5f11/pipeline.log\">pipeline</a>"]},{"id":"a761405e-d8f7-45ea-8f43-248798aaa8bf","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":908.717646,"created":"2025-06-30T11:40:05.788358","updated":"2025-06-30T11:40:05.788365","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a761405e-d8f7-45ea-8f43-248798aaa8bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a761405e-d8f7-45ea-8f43-248798aaa8bf/pipeline.log\">pipeline</a>"]},{"id":"f3d86b87-4b7a-45bf-9c7d-4c82d35a39c6","name":"RHEL9 - base","status":"complete","outcome":"passed","runTime":1039.431296,"created":"2025-06-30T11:40:05.051667","updated":"2025-06-30T11:40:05.051674","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3d86b87-4b7a-45bf-9c7d-4c82d35a39c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3d86b87-4b7a-45bf-9c7d-4c82d35a39c6/pipeline.log\">pipeline</a>"]},{"id":"5ab1b694-8ac6-465a-a2ad-aff99950ea15","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":1346.346643,"created":"2025-06-10T14:10:18.693285","updated":"2025-06-10T14:10:18.693292","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ab1b694-8ac6-465a-a2ad-aff99950ea15\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ab1b694-8ac6-465a-a2ad-aff99950ea15/pipeline.log\">pipeline</a>"]},{"id":"004c4db1-83e1-46bf-9bb0-dd2408296475","name":"RHEL8 - core","runTime":976.223665,"created":"2025-06-30T11:40:05.604020","updated":"2025-06-30T11:40:05.604026","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/004c4db1-83e1-46bf-9bb0-dd2408296475\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/004c4db1-83e1-46bf-9bb0-dd2408296475/pipeline.log\">pipeline</a>"]},{"id":"f7dd1e3f-d0f1-4137-87cf-407668ab0c2c","name":"RHEL10 - base","status":"complete","outcome":"passed","runTime":724.873714,"created":"2025-06-30T11:40:06.369901","updated":"2025-06-30T11:40:06.369906","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f7dd1e3f-d0f1-4137-87cf-407668ab0c2c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f7dd1e3f-d0f1-4137-87cf-407668ab0c2c/pipeline.log\">pipeline</a>"]}]} -->