### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -17,7 +17,6 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="s2i-base rhel10" \
       com.redhat.component="s2i-base-container" \
       name="ubi10/s2i-base" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 # This is the list of basic dependencies that all language container image can

--- a/core/Dockerfile.rhel10
+++ b/core/Dockerfile.rhel10
@@ -17,7 +17,6 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="s2i-core rhel10" \
       com.redhat.component="s2i-core-container" \
       name="ubi10/s2i-core" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 
 ENV \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279126062"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279201944","data":[{"id":"99dbb4f2-22e8-4f10-9e66-5bdf6d7e82de","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":483.46753,"created":"2025-09-12T09:44:34.850243","updated":"2025-09-12T09:44:34.850251","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/99dbb4f2-22e8-4f10-9e66-5bdf6d7e82de\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/99dbb4f2-22e8-4f10-9e66-5bdf6d7e82de/pipeline.log\">pipeline</a>"]},{"id":"9d8293b0-2922-4fad-b5f9-33a8b28d5125","name":"Fedora - base","status":"complete","outcome":"passed","runTime":386.644011,"created":"2025-09-12T09:47:39.066577","updated":"2025-09-12T09:47:39.066584","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9d8293b0-2922-4fad-b5f9-33a8b28d5125\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9d8293b0-2922-4fad-b5f9-33a8b28d5125/pipeline.log\">pipeline</a>"]},{"id":"6e457c52-7f49-48b8-86d0-581156dd6f1e","name":"Fedora - core","status":"complete","outcome":"passed","runTime":378.084366,"created":"2025-09-12T09:44:32.019307","updated":"2025-09-12T09:44:32.019313","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6e457c52-7f49-48b8-86d0-581156dd6f1e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6e457c52-7f49-48b8-86d0-581156dd6f1e/pipeline.log\">pipeline</a>"]},{"id":"c5af0edc-5a26-44d4-890b-1d98af0ec0aa","name":"CentOS Stream 9 - core","status":"complete","outcome":"passed","runTime":556.39022,"created":"2025-09-12T09:47:52.430227","updated":"2025-09-12T09:47:52.430233","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c5af0edc-5a26-44d4-890b-1d98af0ec0aa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c5af0edc-5a26-44d4-890b-1d98af0ec0aa/pipeline.log\">pipeline</a>"]},{"id":"425171e4-183d-446d-8be8-f2372a136422","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":472.300491,"created":"2025-09-12T09:44:36.004189","updated":"2025-09-12T09:44:36.004194","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/425171e4-183d-446d-8be8-f2372a136422\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/425171e4-183d-446d-8be8-f2372a136422/pipeline.log\">pipeline</a>"]},{"id":"cd170230-6d96-4816-b310-9925170b7e03","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":558.736806,"created":"2025-09-12T09:44:33.335646","updated":"2025-09-12T09:44:33.335654","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cd170230-6d96-4816-b310-9925170b7e03\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cd170230-6d96-4816-b310-9925170b7e03/pipeline.log\">pipeline</a>"]},{"id":"9fa2d17a-6d81-4125-be32-dd010cd456ce","name":"RHEL10 - core","status":"complete","outcome":"passed","runTime":771.806599,"created":"2025-09-12T09:44:35.284136","updated":"2025-09-12T09:44:35.284146","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fa2d17a-6d81-4125-be32-dd010cd456ce\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fa2d17a-6d81-4125-be32-dd010cd456ce/pipeline.log\">pipeline</a>"]},{"id":"4463dc8f-943e-453d-881a-822838904205","name":"RHEL10 - base","status":"complete","outcome":"passed","runTime":746.800754,"created":"2025-09-12T09:44:33.272513","updated":"2025-09-12T09:44:33.272519","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4463dc8f-943e-453d-881a-822838904205\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4463dc8f-943e-453d-881a-822838904205/pipeline.log\">pipeline</a>"]},{"id":"86178451-9b32-4cf7-84fc-1e0f14ebd03e","name":"RHEL8 - core","status":"complete","outcome":"passed","runTime":914.690005,"created":"2025-09-12T09:47:43.344303","updated":"2025-09-12T09:47:43.344311","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/86178451-9b32-4cf7-84fc-1e0f14ebd03e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/86178451-9b32-4cf7-84fc-1e0f14ebd03e/pipeline.log\">pipeline</a>"]},{"id":"38974fc9-1dce-4be4-be79-e09de0789c9c","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":994.203071,"created":"2025-09-12T09:44:36.211897","updated":"2025-09-12T09:44:36.211905","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/38974fc9-1dce-4be4-be79-e09de0789c9c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/38974fc9-1dce-4be4-be79-e09de0789c9c/pipeline.log\">pipeline</a>"]},{"id":"0ea3e0e7-d49a-4da0-ab94-a3e2bb06fbc4","name":"RHEL9 - base","runTime":1243.233147,"created":"2025-09-12T09:44:33.331587","updated":"2025-09-12T09:44:33.331593","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ea3e0e7-d49a-4da0-ab94-a3e2bb06fbc4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ea3e0e7-d49a-4da0-ab94-a3e2bb06fbc4/pipeline.log\">pipeline</a>"]},{"id":"d7326eed-f075-4662-8da6-8d29bacc03d5","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":1109.485576,"created":"2025-09-12T09:44:36.540207","updated":"2025-09-12T09:44:36.540213","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7326eed-f075-4662-8da6-8d29bacc03d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7326eed-f075-4662-8da6-8d29bacc03d5/pipeline.log\">pipeline</a>"]}]} -->