### PR TITLE
Disable scheduled auto-merge-on-demand and use /auto-merge instead of

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -1,8 +1,8 @@
-name: Auto Merge Scheduled / On Demand
+name: Auto Merge On Demand
 on:
-  schedule:
-    # Workflow runs every 45 minutes
-    - cron: '*/45 * * * *'
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       pr-number:
@@ -16,7 +16,10 @@ permissions:
 jobs:
   # Get all open PRs
   gather-pull-requests:
-    if: github.repository_owner == 'sclorg'
+    if: |
+      github.repository_owner == 'sclorg'
+      || (contains(github.event.comment.body, '/auto-merge')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION
Sometimes we reached GitHub limits, like here: https://github.com/sclorg/s2i-nodejs-container/pull/500

So turn-off auto-merge schedule also for s2i-base-container

<!-- issue-commentator = {"comment-id":"3311354447"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3311532404","data":[{"id":"2e4fdc88-4bd3-4943-9734-c23d5beed0cf","name":"RHEL10 - core","status":"complete","outcome":"passed","runTime":721.600593,"created":"2025-09-19T11:27:45.051171","updated":"2025-09-19T11:27:45.051180","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e4fdc88-4bd3-4943-9734-c23d5beed0cf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e4fdc88-4bd3-4943-9734-c23d5beed0cf/pipeline.log\">pipeline</a>"]},{"id":"d9cb5d8a-da79-463f-a7be-c01620363e7b","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":447.151232,"created":"2025-09-19T09:52:26.083803","updated":"2025-09-19T09:52:26.083810","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d9cb5d8a-da79-463f-a7be-c01620363e7b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d9cb5d8a-da79-463f-a7be-c01620363e7b/pipeline.log\">pipeline</a>"]},{"id":"072eabe2-efbb-4e79-8723-8f9fdd72f760","name":"Fedora - core","status":"complete","outcome":"passed","runTime":434.108455,"created":"2025-09-19T09:52:27.882727","updated":"2025-09-19T09:52:27.882732","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/072eabe2-efbb-4e79-8723-8f9fdd72f760\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/072eabe2-efbb-4e79-8723-8f9fdd72f760/pipeline.log\">pipeline</a>"]},{"id":"8bc0f6b4-0635-4f73-9305-74ddb970c919","name":"CentOS Stream 9 - core","status":"complete","outcome":"passed","runTime":569.055947,"created":"2025-09-19T09:52:25.493421","updated":"2025-09-19T09:52:25.493426","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8bc0f6b4-0635-4f73-9305-74ddb970c919\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8bc0f6b4-0635-4f73-9305-74ddb970c919/pipeline.log\">pipeline</a>"]},{"id":"cf7ff9e6-741c-41a4-85bb-40428f0159c0","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":591.271269,"created":"2025-09-19T09:52:27.550165","updated":"2025-09-19T09:52:27.550171","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cf7ff9e6-741c-41a4-85bb-40428f0159c0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cf7ff9e6-741c-41a4-85bb-40428f0159c0/pipeline.log\">pipeline</a>"]},{"id":"78076b0e-68c5-4105-849b-3cc7615c3b9f","name":"Fedora - base","status":"complete","outcome":"passed","runTime":537.935996,"created":"2025-09-19T09:52:27.681645","updated":"2025-09-19T09:52:27.681651","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/78076b0e-68c5-4105-849b-3cc7615c3b9f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/78076b0e-68c5-4105-849b-3cc7615c3b9f/pipeline.log\">pipeline</a>"]},{"id":"94e28bc1-184b-495b-8e69-f46d66d56143","name":"RHEL8 - core","status":"complete","outcome":"passed","runTime":965.197081,"created":"2025-09-19T11:27:45.648700","updated":"2025-09-19T11:27:45.648707","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/94e28bc1-184b-495b-8e69-f46d66d56143\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/94e28bc1-184b-495b-8e69-f46d66d56143/pipeline.log\">pipeline</a>"]},{"id":"3339395c-844b-4496-aa14-e95b6e649ec5","name":"RHEL10 - base","status":"complete","outcome":"passed","runTime":749.502435,"created":"2025-09-19T11:27:45.696346","updated":"2025-09-19T11:27:45.696353","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3339395c-844b-4496-aa14-e95b6e649ec5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3339395c-844b-4496-aa14-e95b6e649ec5/pipeline.log\">pipeline</a>"]},{"id":"b4926946-12db-4a86-ba6c-0bd4e3a86f59","name":"RHEL9 - base","runTime":1117.358178,"created":"2025-09-19T11:27:47.134983","updated":"2025-09-19T11:27:47.134989","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4926946-12db-4a86-ba6c-0bd4e3a86f59\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4926946-12db-4a86-ba6c-0bd4e3a86f59/pipeline.log\">pipeline</a>"]},{"id":"5ef43194-8c6f-4d45-ab58-41326abd3d87","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":964.728982,"created":"2025-09-19T09:52:25.568868","updated":"2025-09-19T09:52:25.568877","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ef43194-8c6f-4d45-ab58-41326abd3d87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ef43194-8c6f-4d45-ab58-41326abd3d87/pipeline.log\">pipeline</a>"]},{"id":"8760a17f-bc68-4057-81e5-661250e3acf8","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":1118.634499,"created":"2025-09-19T11:27:45.279057","updated":"2025-09-19T11:27:45.279066","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8760a17f-bc68-4057-81e5-661250e3acf8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8760a17f-bc68-4057-81e5-661250e3acf8/pipeline.log\">pipeline</a>"]}]} -->