### PR TITLE
Add F44 dockerfiles and update build and push workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -75,6 +75,14 @@ jobs:
             use_default_tags: 'false'
             arch: "amd64, ppc64le, s390x, arm64"
 
+          - dockerfile: "Dockerfile.f44"
+            registry_namespace: "fedora"
+            tag: "44"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            use_default_tags: 'false'
+            arch: "amd64, ppc64le, s390x, arm64"
+
     steps:
       - name: Build and push s2i-core to quay.io registry
         uses: sclorg/build-and-push-action@v4

--- a/base/Dockerfile.f44
+++ b/base/Dockerfile.f44
@@ -1,0 +1,48 @@
+FROM quay.io/fedora/s2i-core:44
+
+ENV SUMMARY="Base image with essential libraries and tools used as a base for \
+builder images like perl, python, ruby, etc." \
+    DESCRIPTION="The s2i-base image, being built upon s2i-core, provides any \
+images layered on top of it with all the tools needed to use source-to-image \
+functionality. Additionally, s2i-base also contains various libraries needed for \
+it to serve as a base for other builder images, like s2i-python or s2i-ruby." \
+    NAME=s2i-base \
+    ARCH=x86_64
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i base" \
+      com.redhat.component="$NAME" \
+      name="fedora/$NAME" \
+      version="$VERSION" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+RUN INSTALL_PKGS="autoconf \
+  automake \
+  bzip2 \
+  gcc-c++ \
+  gd-devel \
+  gdb \
+  git \
+  libcurl-devel \
+  libpq-devel \
+  libxml2-devel \
+  libxslt-devel \
+  lsof \
+  make \
+  mariadb-connector-c-devel \
+  nodejs24-npm \
+  openssl-devel \
+  patch \
+  procps-ng \
+  sqlite-devel \
+  unzip \
+  wget2 \
+  which \
+  zlib-ng-compat-devel" && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf clean all -y

--- a/base/Dockerfile.fedora
+++ b/base/Dockerfile.fedora
@@ -1,1 +1,1 @@
-Dockerfile.f43
+Dockerfile.f44

--- a/core/Dockerfile.f44
+++ b/core/Dockerfile.f44
@@ -1,0 +1,71 @@
+# This image is the base image for all s2i configurable container images.
+FROM quay.io/fedora/fedora:44
+
+ENV SUMMARY="Base image which allows using of source-to-image."	\
+    DESCRIPTION="The s2i-core image provides any images layered on top of it \
+with all the tools needed to use source-to-image functionality while keeping \
+the image size as small as possible." \
+    NAME=s2i-core \
+    VERSION=44 \
+    ARCH=x86_64
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="s2i core" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+      io.s2i.scripts-url=image:///usr/libexec/s2i \
+      com.redhat.component="$NAME" \
+      name="fedora/$NAME" \
+      version="$VERSION" \
+      usage="This image is supposed to be used as a base image for other images that support source-to-image" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+ENV \
+    # DEPRECATED: Use above LABEL instead, because this will be removed in future versions.
+    STI_SCRIPTS_URL=image:///usr/libexec/s2i \
+    # Path to be used in other layers to place s2i scripts into
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
+    PLATFORM="fedora"
+
+# This is the list of basic dependencies that all language container image can
+# consume.
+# Also setup the 'openshift' user that is used for the build execution and for the
+# application runtime execution.
+# TODO: Use better UID and GID values
+RUN INSTALL_PKGS="bsdtar \
+  findutils \
+  gettext \
+  glibc-langpack-en \
+  groff-base \
+  python3 \
+  rsync \
+  tar \
+  unzip" && \
+  mkdir -p ${HOME}/.pki/nssdb && \
+  chown -R 1001:0 ${HOME}/.pki && \
+  dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  dnf clean all -y
+
+# Copy extra files to the image.
+COPY ./core/root/ /
+
+# Create a platform-python symlink if it does not exist already
+RUN [ -e /usr/libexec/platform-python ] || ln -s /usr/bin/python3 /usr/libexec/platform-python
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["base-usage"]
+
+# Reset permissions of modified directories and add default user
+RUN rpm-file-permissions && \
+  useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT}

--- a/core/Dockerfile.fedora
+++ b/core/Dockerfile.fedora
@@ -1,1 +1,1 @@
-Dockerfile.f43
+Dockerfile.f44


### PR DESCRIPTION
Fedora 44 is GO and releases today, so we're safe to use it for our images.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->



<!-- issue-commentator = {"comment-id":"4335612568"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4335603214","data":[{"id":"6403abee-3506-4dfd-9f8d-c3feb2b2e01c","name":"RHEL10 - core","status":"complete","outcome":"error","runTime":411.013247,"created":"2026-04-28T13:11:46.964364","updated":"2026-04-28T13:11:46.964370","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6403abee-3506-4dfd-9f8d-c3feb2b2e01c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6403abee-3506-4dfd-9f8d-c3feb2b2e01c/pipeline.log\">pipeline</a>"]},{"id":"04fb962b-05c9-452a-a030-bafbcdeba5e6","name":"RHEL10 - base","status":"complete","outcome":"error","runTime":412.984516,"created":"2026-04-28T13:11:53.165396","updated":"2026-04-28T13:11:53.165416","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04fb962b-05c9-452a-a030-bafbcdeba5e6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04fb962b-05c9-452a-a030-bafbcdeba5e6/pipeline.log\">pipeline</a>"]},{"id":"3e0eafbf-401a-4f96-899f-02c726460915","name":"CentOS Stream 10 - PyTest - core","status":"complete","outcome":"passed","runTime":590.476653,"created":"2026-04-28T13:11:46.455521","updated":"2026-04-28T13:11:46.455529","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3e0eafbf-401a-4f96-899f-02c726460915\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3e0eafbf-401a-4f96-899f-02c726460915/pipeline.log\">pipeline</a>"]},{"id":"e53b75e4-eaa7-4240-909d-f831eebd0337","name":"CentOS Stream 10 - core","status":"complete","outcome":"passed","runTime":572.059731,"created":"2026-04-28T13:11:48.422242","updated":"2026-04-28T13:11:48.422250","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e53b75e4-eaa7-4240-909d-f831eebd0337\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e53b75e4-eaa7-4240-909d-f831eebd0337/pipeline.log\">pipeline</a>"]},{"id":"be4298ac-ebe6-4d83-8aad-680554b4f83d","name":"CentOS Stream 10 - PyTest - base","status":"complete","outcome":"passed","runTime":565.513709,"created":"2026-04-28T13:11:46.685812","updated":"2026-04-28T13:11:46.685821","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/be4298ac-ebe6-4d83-8aad-680554b4f83d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/be4298ac-ebe6-4d83-8aad-680554b4f83d/pipeline.log\">pipeline</a>"]},{"id":"74f25a65-671c-485e-80a9-48e9b3d3423f","name":"CentOS Stream 9 - PyTest - core","status":"complete","outcome":"passed","runTime":552.887026,"created":"2026-04-28T13:11:48.453002","updated":"2026-04-28T13:11:48.453010","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/74f25a65-671c-485e-80a9-48e9b3d3423f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/74f25a65-671c-485e-80a9-48e9b3d3423f/pipeline.log\">pipeline</a>"]},{"id":"d1d45773-f7ac-4cb2-9349-ba28f223b6f7","name":"Fedora - PyTest - core","status":"complete","outcome":"error","runTime":630.94765,"created":"2026-04-28T13:11:46.681158","updated":"2026-04-28T13:11:46.681168","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d1d45773-f7ac-4cb2-9349-ba28f223b6f7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d1d45773-f7ac-4cb2-9349-ba28f223b6f7/pipeline.log\">pipeline</a>"]},{"id":"a06296cb-3fdd-484b-9c97-08281d3e964b","name":"Fedora - PyTest - base","status":"complete","outcome":"error","runTime":641.743524,"created":"2026-04-28T13:11:49.284969","updated":"2026-04-28T13:11:49.284975","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a06296cb-3fdd-484b-9c97-08281d3e964b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a06296cb-3fdd-484b-9c97-08281d3e964b/pipeline.log\">pipeline</a>"]},{"id":"15138575-4343-48cf-85dc-bbd6685c198c","name":"CentOS Stream 9 - base","status":"complete","outcome":"passed","runTime":629.211193,"created":"2026-04-28T13:11:48.360861","updated":"2026-04-28T13:11:48.360869","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/15138575-4343-48cf-85dc-bbd6685c198c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/15138575-4343-48cf-85dc-bbd6685c198c/pipeline.log\">pipeline</a>"]},{"id":"40a4e679-8a97-4b77-947e-dc7420226ad2","name":"Fedora - core","status":"complete","outcome":"error","runTime":648.862717,"created":"2026-04-28T13:11:47.090451","updated":"2026-04-28T13:11:47.090456","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/40a4e679-8a97-4b77-947e-dc7420226ad2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/40a4e679-8a97-4b77-947e-dc7420226ad2/pipeline.log\">pipeline</a>"]},{"id":"4aa9965f-e56d-40d5-836d-8338c1321962","name":"RHEL8 - core","status":"complete","outcome":"passed","runTime":878.452322,"created":"2026-04-28T13:11:48.804704","updated":"2026-04-28T13:11:48.804711","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4aa9965f-e56d-40d5-836d-8338c1321962\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4aa9965f-e56d-40d5-836d-8338c1321962/pipeline.log\">pipeline</a>"]},{"id":"0577bf61-7286-4dd1-9477-b681ff9581bf","name":"RHEL8 - PyTest - base","status":"complete","outcome":"passed","runTime":867.697969,"created":"2026-04-28T13:11:48.118698","updated":"2026-04-28T13:11:48.118704","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0577bf61-7286-4dd1-9477-b681ff9581bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0577bf61-7286-4dd1-9477-b681ff9581bf/pipeline.log\">pipeline</a>"]},{"id":"768ca491-e8a6-4297-b38e-c88d3adb4db3","name":"CentOS Stream 9 - PyTest - base","status":"complete","outcome":"passed","runTime":703.022232,"created":"2026-04-28T13:20:09.811663","updated":"2026-04-28T13:20:09.811674","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/768ca491-e8a6-4297-b38e-c88d3adb4db3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/768ca491-e8a6-4297-b38e-c88d3adb4db3/pipeline.log\">pipeline</a>"]},{"id":"43384bc8-1b71-4c47-8757-faeba5e34b38","name":"CentOS Stream 10 - base","status":"complete","outcome":"passed","runTime":557.81881,"created":"2026-04-28T13:22:09.744287","updated":"2026-04-28T13:22:09.744295","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/43384bc8-1b71-4c47-8757-faeba5e34b38\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/43384bc8-1b71-4c47-8757-faeba5e34b38/pipeline.log\">pipeline</a>"]},{"id":"7b97fb2a-0391-42a7-a949-f48a0fc505fc","name":"RHEL9 - core","status":"complete","outcome":"passed","runTime":1309.487516,"created":"2026-04-28T13:11:47.836323","updated":"2026-04-28T13:11:47.836329","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b97fb2a-0391-42a7-a949-f48a0fc505fc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b97fb2a-0391-42a7-a949-f48a0fc505fc/pipeline.log\">pipeline</a>"]},{"id":"1052bbaa-0c3d-4be3-b627-8997996c81c3","name":"RHEL9 - PyTest - base","status":"complete","outcome":"passed","runTime":1307.337922,"created":"2026-04-28T13:11:47.961676","updated":"2026-04-28T13:11:47.961684","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1052bbaa-0c3d-4be3-b627-8997996c81c3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1052bbaa-0c3d-4be3-b627-8997996c81c3/pipeline.log\">pipeline</a>"]},{"id":"53a7b790-9e20-49d2-901f-797c9748ac98","name":"RHEL10 - PyTest - base","status":"complete","outcome":"passed","runTime":1040.396715,"created":"2026-04-28T13:20:16.268591","updated":"2026-04-28T13:20:16.268598","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53a7b790-9e20-49d2-901f-797c9748ac98\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53a7b790-9e20-49d2-901f-797c9748ac98/pipeline.log\">pipeline</a>"]},{"id":"1e0f9a5a-b4cb-415f-a926-82712ed10535","name":"RHEL8 - PyTest - core","status":"complete","outcome":"passed","runTime":1029.667345,"created":"2026-04-28T13:21:23.202225","updated":"2026-04-28T13:21:23.202231","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1e0f9a5a-b4cb-415f-a926-82712ed10535\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1e0f9a5a-b4cb-415f-a926-82712ed10535/pipeline.log\">pipeline</a>"]},{"id":"359be79f-b5a6-4da8-bc38-82401047b0ee","name":"RHEL8 - base","status":"complete","outcome":"passed","runTime":1016.855249,"created":"2026-04-28T13:22:11.236751","updated":"2026-04-28T13:22:11.236757","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/359be79f-b5a6-4da8-bc38-82401047b0ee\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/359be79f-b5a6-4da8-bc38-82401047b0ee/pipeline.log\">pipeline</a>"]},{"id":"839a8e5b-2f26-47de-bd3c-366612c7dc6d","name":"RHEL10 - PyTest - core","runTime":1212.172603,"created":"2026-04-28T13:22:05.934846","updated":"2026-04-28T13:22:05.934855","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/839a8e5b-2f26-47de-bd3c-366612c7dc6d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/839a8e5b-2f26-47de-bd3c-366612c7dc6d/pipeline.log\">pipeline</a>"]}]} -->